### PR TITLE
add support for self intersection

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -471,19 +471,19 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
         case (t, d) if d.isEmpty && t.size == 1 =>
           Broken.Single(t.head)
         case (t, d) =>
-          Broken.Compound(t, d)
+          Broken.Compound(t.toSet, d.toSet)
       }
     }
 
-    private def breakRefinement0(t: Type): (Set[Type], Set[SymbolApi]) = {
+    private def breakRefinement0(t: Type): (List[Type], List[SymbolApi]) = {
       fullDealias(t) match {
         case UniRefinement(parents, decls) =>
           val parts = parents.map(breakRefinement0)
           val types = parts.flatMap(_._1)
           val d = parts.flatMap(_._2)
-          (types.toSet, (decls ++ d).toSet)
+          (types, (decls ++ d))
         case t =>
-          (Set(t), Set.empty)
+          (List(t), List.empty)
 
       }
     }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LightTypeTagTest.scala
@@ -215,6 +215,10 @@ class LightTypeTagTest extends TagAssertions {
       assertSame(tag1, `LTT[_,_]`[Either])
     }
 
+    "support self-intersection (X with X)" in {
+      assertSame(`LTT`[String with String], `LTT`[String])
+    }
+
     "support intersection type equality" in {
       type T1[A] = W3[A] with W1
       type T2[A] = W4[A] with W2


### PR DESCRIPTION
This is an attempt to fix the handling of self-intersection tags. See Issue #12 .
I'm basically handling `X with X` as a single-element compound/intersection type, which doesn't seem to be too far off. It passes all the tests and I added a new one for self-intersection.

please let me know what you think