### PR TITLE
Dotty: support distinctions between LTTs of simple subtypes

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
@@ -29,8 +29,9 @@ abstract class Inspector(protected val shift: Int) extends InspectorBase {
   private[dottyreflection] def fixReferenceName(reference: AbstractReference, typeRepr: TypeRepr): AbstractReference =
     reference match {
       // if boundaries are defined, this is a unique type, and the type name should be fixed to the (dealiased) declaration
-      case NameReference(x, boundaries: Boundaries.Defined, prefix) =>
-        NameReference(SymName.SymTypeName(typeRepr.dealias.typeSymbol.name), boundaries, prefix)
+      case NameReference(_, boundaries: Boundaries.Defined, _) =>
+        val dealiased = typeRepr.dealias.typeSymbol
+        NameReference(SymName.SymTypeName(dealiased.name), boundaries, prefixOf(dealiased))
       case x => x
     }
 

--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
@@ -155,8 +155,7 @@ abstract class Inspector(protected val shift: Int) extends InspectorBase {
 
     tpe match {
       case t: TypeBounds =>
-        val x = inspectTType(t.hi)
-        TypeParam(x, variance)
+        TypeParam(inspectTType(t.hi), variance)
       case t: TypeRepr =>
         TypeParam(inspectTType(t), variance)
     }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
@@ -20,6 +20,8 @@ package izumi.reflect.test
 
 import scala.annotation.StaticAnnotation
 
+import izumi.reflect.macrortti.LTag
+
 object TestModel extends TestModelKindProjector {
   final class IdAnnotation(val name: String) extends StaticAnnotation
 
@@ -136,4 +138,11 @@ object TestModel extends TestModelKindProjector {
   trait KT2[+A2, +B2] extends KT1[B2, A2]
   trait KK1[+A, +B, +U]
   trait KK2[+A, +B] extends KK1[B, A, Unit]
+
+  class \/[L, R](implicit lt: LTag[L], rt: LTag[R])
+  type SubStrA <: String
+  type SubStrB <: String
+  type SubStrC = String
+  type SubStrD = SubStrA
+  type SubSubStr <: SubStrA
 }

--- a/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
@@ -127,14 +127,14 @@ class LightTypeTagTest extends TagAssertions {
       assertChild(LTT[Option[Nothing]], LTT[Option[Int]])
       //assertChild(LTT[None.type], LTT[Option[Int]])
 
-//      assertChild(LTT[Option[W2]], LTT[Option[_ <: W1]]) // TODO: Fix regression
+      assertChild(LTT[Option[W2]], LTT[Option[_ <: W1]])
       assertNotChild(LTT[Option[W2]], LTT[Option[_ <: I1]])
 
-//      assertChild(LTT[Option[H3]], LTT[Option[_ >: H4 <: H2]]) // TODO: Fix regression
+      assertChild(LTT[Option[H3]], LTT[Option[_ >: H4 <: H2]])
       assertNotChild(LTT[Option[H1]], LTT[Option[_ >: H4 <: H2]])
 
       // bottom boundary is weird!
-//      assertChild(LTT[Option[H5]], LTT[Option[_ >: H4 <: H2]]) // TODO: Fix regression
+      assertChild(LTT[Option[H5]], LTT[Option[_ >: H4 <: H2]])
 
       // I consider this stuff practically useless
       type X[A >: H4 <: H2] = Option[A]

--- a/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
@@ -47,6 +47,7 @@ class LightTypeTagTest extends TagAssertions {
 //    }
 
     "support distinction between subtypes" in {
+      class \/[L, R](implicit lt: LTag[L], rt: LTag[R])
       type SubStrA <: String
       type SubStrB <: String
       type SubStrC = String
@@ -56,6 +57,8 @@ class LightTypeTagTest extends TagAssertions {
       val tag2 = LTT[SubStrA]
       val tag3 = LTT[SubStrB]
       val tag4 = LTT[SubStrD]
+      val foo = LTT[SubStrA \/ Int]
+      val bar =  `LTT[_,_]`[\/].combine(tag2, LTT[Int])
 
       assertDifferent(tag2, tag1)
       assertChild(tag2, tag1)
@@ -64,6 +67,7 @@ class LightTypeTagTest extends TagAssertions {
       assertSame(tag, tag1)
       assertNotChild(tag2, tag3)
       assertSame(tag2, tag4)
+      assertSame(foo, bar)
     }
 
     "support typetag combination" in {
@@ -123,14 +127,14 @@ class LightTypeTagTest extends TagAssertions {
       assertChild(LTT[Option[Nothing]], LTT[Option[Int]])
       //assertChild(LTT[None.type], LTT[Option[Int]])
 
-      assertChild(LTT[Option[W2]], LTT[Option[_ <: W1]])
+//      assertChild(LTT[Option[W2]], LTT[Option[_ <: W1]]) // TODO: Fix regression
       assertNotChild(LTT[Option[W2]], LTT[Option[_ <: I1]])
 
-      assertChild(LTT[Option[H3]], LTT[Option[_ >: H4 <: H2]])
+//      assertChild(LTT[Option[H3]], LTT[Option[_ >: H4 <: H2]]) // TODO: Fix regression
       assertNotChild(LTT[Option[H1]], LTT[Option[_ >: H4 <: H2]])
 
       // bottom boundary is weird!
-      assertChild(LTT[Option[H5]], LTT[Option[_ >: H4 <: H2]])
+//      assertChild(LTT[Option[H5]], LTT[Option[_ >: H4 <: H2]]) // TODO: Fix regression
 
       // I consider this stuff practically useless
       type X[A >: H4 <: H2] = Option[A]

--- a/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
@@ -46,6 +46,26 @@ class LightTypeTagTest extends TagAssertions {
 //      assertRepr(`LTT[_]`[S[Unit, *]], "λ %0 → Either[+0,+Unit]")
 //    }
 
+    "support distinction between subtypes" in {
+      type SubStrA <: String
+      type SubStrB <: String
+      type SubStrC = String
+      type SubStrD = SubStrA
+      val tag = LTT[SubStrC]
+      val tag1 = LTT[String]
+      val tag2 = LTT[SubStrA]
+      val tag3 = LTT[SubStrB]
+      val tag4 = LTT[SubStrD]
+
+      assertDifferent(tag2, tag1)
+      assertChild(tag2, tag1)
+      assertNotChild(tag1, tag2)
+      assertDifferent(tag2, tag3)
+      assertSame(tag, tag1)
+      assertNotChild(tag2, tag3)
+      assertSame(tag2, tag4)
+    }
+
     "support typetag combination" in {
       assertCombine(`LTT[_[_]]`[T1], `LTT[_]`[Id], LTT[T1[Id]])
       assertCombine(`LTT[_[_]]`[T1], `LTT[_]`[FP], LTT[T1[FP]])

--- a/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
@@ -19,9 +19,10 @@
 package izumi.reflect.test
 
 import izumi.reflect.macrortti._
-
+import izumi.reflect.macrortti.LightTypeTagRef.{AbstractReference, AppliedNamedReference, Boundaries}
 import scala.collection.immutable.ListSet
 import scala.collection.{BitSet, immutable, mutable}
+
 
 class LightTypeTagTest extends TagAssertions {
 //object LightTypeTagTest extends TagAssertions {
@@ -47,26 +48,35 @@ class LightTypeTagTest extends TagAssertions {
 //    }
 
     "support distinction between subtypes" in {
-      class \/[L, R](implicit lt: LTag[L], rt: LTag[R])
-      type SubStrA <: String
-      type SubStrB <: String
-      type SubStrC = String
-      type SubStrD = SubStrA
-      val tag = LTT[SubStrC]
-      val tag1 = LTT[String]
-      val tag2 = LTT[SubStrA]
-      val tag3 = LTT[SubStrB]
-      val tag4 = LTT[SubStrD]
+      val strLTT = LTT[String]
+      val subStrALTT = LTT[SubStrA]
+      val subStrCLTT = LTT[SubStrC]
+      val subStrBLTT = LTT[SubStrB]
+      val subStrDLTT = LTT[SubStrD]
+      val subSubStrLTT = LTT[SubSubStr]
       val foo = LTT[SubStrA \/ Int]
-      val bar =  `LTT[_,_]`[\/].combine(tag2, LTT[Int])
-
-      assertDifferent(tag2, tag1)
-      assertChild(tag2, tag1)
-      assertNotChild(tag1, tag2)
-      assertDifferent(tag2, tag3)
-      assertSame(tag, tag1)
-      assertNotChild(tag2, tag3)
-      assertSame(tag2, tag4)
+      val bar = `LTT[_,_]`[\/].combine(subStrALTT, LTT[Int])
+      val strUnpacker = LightTypeTagUnpacker(strLTT)
+      val substrUnpacker = LightTypeTagUnpacker(subStrALTT)
+      val subsubstrUnpacker = LightTypeTagUnpacker(subSubStrLTT)
+      assert(subStrALTT.repr == "izumi.reflect.test.TestModel$::SubStrA|<scala.Nothing..java.lang.String>")
+      val nothingRef = LTT[Nothing].ref.asInstanceOf[AppliedNamedReference]
+      val anyRef = LTT[Any].ref.asInstanceOf[AppliedNamedReference]
+      assert(substrUnpacker.bases == strUnpacker.bases + (nothingRef -> Set(anyRef)))
+      assert(substrUnpacker.inheritance == strUnpacker.inheritance + (nothingRef.asName -> Set(anyRef)))
+      assert(subsubstrUnpacker.bases == strUnpacker.bases + (nothingRef -> Set(anyRef)))
+      assert(subsubstrUnpacker.inheritance == strUnpacker.inheritance + (nothingRef.asName -> Set(anyRef)))
+      assertDifferent(subStrALTT, strLTT)
+      assertChild(subStrALTT, strLTT)
+      assertChild(subSubStrLTT, strLTT)
+      assertChild(subSubStrLTT, subStrALTT)
+      assertNotChild(strLTT, subStrALTT)
+      assertNotChild(subStrALTT, subSubStrLTT)
+      assertNotChild(subSubStrLTT, subStrBLTT)
+      assertDifferent(subStrALTT, subStrBLTT)
+      assertSame(subStrCLTT, strLTT)
+      assertNotChild(subStrALTT, subStrBLTT)
+      assertSame(subStrALTT, subStrDLTT)
       assertSame(foo, bar)
     }
 


### PR DESCRIPTION
e.g. (type T <: String) =:= String should be false (see new test cases)
Seemed the lightest reasonable implementation, but there's a lot of this codebase I don't exactly grok yet.
Doesn't seem to be a ticket that corresponds to this
~I also didn't see any similar tests in the commented-out part of the dotty LTT tests, but highly possible I just missed them~ this doesn't seem to fix any of the commented-out tests so I'm assuming there's either no existing coverage of this, or the coverage that exists uses some much more advanced wizardry