### PR TITLE
change ? to * to fix kind-projector warnings

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -79,7 +79,7 @@ abstract class LightTypeTag(
     * lambda taking remaining arguments:
     *
     * {{{
-    *   F[?, ?, ?].combine(A, B) = F[A, B, ?]
+    *   F[*, *, *].combine(A, B) = F[A, B, *]
     * }}}
     */
   def combine(args: LightTypeTag*): LightTypeTag = {
@@ -110,7 +110,7 @@ abstract class LightTypeTag(
     * The resulting type lambda will take parameters in places where `args` was None:
     *
     * {{{
-    *   F[?, ?, ?].combine(Some(A), None, Some(C)) = F[A, ?, C]
+    *   F[*, *, *].combine(Some(A), None, Some(C)) = F[A, *, C]
     * }}}
     */
   def combineNonPos(args: Option[LightTypeTag]*): LightTypeTag = {

--- a/izumi-reflect/izumi-reflect/src/main/scala_2/izumi/reflect/Tags.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_2/izumi/reflect/Tags.scala
@@ -67,7 +67,7 @@ trait AnyTag {
   * Currently some limitations apply as to when a `Tag` will be correctly constructed:
   *   * Type Parameters do not yet resolve inside structural refinements, e.g. T in {{{ Tag[{ def x: T}] }}}
   *   * TagK* does not resolve for constructors with bounded parameters, e.g. S in {{{ class Abc[S <: String]; TagK[Abc] }}}
-  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", ?]] }}}
+  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", *]] }}}
   *   * Further details at [[https://github.com/7mind/izumi/issues/374]]
   *
   * @see "Lightweight Scala Reflection and why Dotty needs TypeTags reimplemented" https://blog.7mind.io/lightweight-reflection.html

--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/Tags.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/Tags.scala
@@ -67,7 +67,7 @@ trait AnyTag {
   * Currently some limitations apply as to when a `Tag` will be correctly constructed:
   *   * Type Parameters do not yet resolve inside structural refinements, e.g. T in {{{ Tag[{ def x: T}] }}}
   *   * TagK* does not resolve for constructors with bounded parameters, e.g. S in {{{ class Abc[S <: String]; TagK[Abc] }}}
-  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", ?]] }}}
+  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", *]] }}}
   *   * Further details at [[https://github.com/7mind/izumi/issues/374]]
   *
   * @see "Lightweight Scala Reflection and why Dotty needs TypeTags reimplemented" https://blog.7mind.io/lightweight-reflection.html

--- a/izumi-reflect/izumi-reflect/src/test/scala_2/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_2/izumi/reflect/test/LightTypeTagTest.scala
@@ -42,8 +42,8 @@ class LightTypeTagTest extends TagAssertions {
       assertRepr(LTT[Id[Int]], "Int")
       assertRepr(LTT[FP[Int]], "List[+Int]")
       assertRepr(`LTT[_]`[L], "λ %0 → List[+0]")
-      assertRepr(`LTT[_]`[Either[Unit, ?]], "λ %0 → Either[+Unit,+0]")
-      assertRepr(`LTT[_]`[S[Unit, ?]], "λ %0 → Either[+0,+Unit]")
+      assertRepr(`LTT[_]`[Either[Unit, *]], "λ %0 → Either[+Unit,+0]")
+      assertRepr(`LTT[_]`[S[Unit, *]], "λ %0 → Either[+0,+Unit]")
     }
 
     "support typetag combination" in {
@@ -51,10 +51,10 @@ class LightTypeTagTest extends TagAssertions {
       assertCombine(`LTT[_[_]]`[T1], `LTT[_]`[FP], LTT[T1[FP]])
       assertCombine(`LTT[_[_]]`[T1], `LTT[_]`[FI], LTT[T1[FI]])
 
-      assertCombine(`LTT[_[_]]`[T0[Id, ?[_]]], `LTT[_]`[FP], LTT[T0[Id, FP]])
+      assertCombine(`LTT[_[_]]`[T0[Id, *[_]]], `LTT[_]`[FP], LTT[T0[Id, FP]])
       assertCombine(`LTT[_[_]]`[T1], `LTT[_]`[List], LTT[T1[List]])
       assertCombine(`LTT[_]`[List], LTT[Int], LTT[List[Int]])
-      assertCombine(`LTT[_,_]`[Either], LTT[Unit], `LTT[_]`[Either[Unit, ?]])
+      assertCombine(`LTT[_,_]`[Either], LTT[Unit], `LTT[_]`[Either[Unit, *]])
 
       assertCombine(`LTT[_[_[_],_[_]]]`[T2], `LTT[_[_],_[_]]`[T0], LTT[T2[T0]])
 
@@ -63,7 +63,7 @@ class LightTypeTagTest extends TagAssertions {
     }
 
     "support non-positional typetag combination" in {
-      assertCombineNonPos(`LTT[_,_]`[Either], Seq(None, Some(LTT[Unit])), `LTT[_]`[Either[?, Unit]])
+      assertCombineNonPos(`LTT[_,_]`[Either], Seq(None, Some(LTT[Unit])), `LTT[_]`[Either[*, Unit]])
     }
 
     "eradicate tautologies" in {
@@ -156,8 +156,8 @@ class LightTypeTagTest extends TagAssertions {
       assertChild(LTT[KK2[H2, I2]], LTT[KK1[I1, H1, Unit]])
       assertNotChild(LTT[KK2[H2, I2]], LTT[KK1[H1, I1, Unit]])
 
-      assertChild(`LTT[_]`[KK2[H2, ?]], `LTT[_]`[KK1[?, H1, Unit]])
-      assertNotChild(`LTT[_]`[KK2[H2, ?]], `LTT[_]`[KK1[H1, ?, Unit]])
+      assertChild(`LTT[_]`[KK2[H2, *]], `LTT[_]`[KK1[*, H1, Unit]])
+      assertNotChild(`LTT[_]`[KK2[H2, *]], `LTT[_]`[KK1[H1, *, Unit]])
     }
 
     "support PDTs" in {
@@ -181,14 +181,14 @@ class LightTypeTagTest extends TagAssertions {
     }
 
     "support subtyping of parents parameterized with type lambdas" in {
-      assertChild(LTT[RoleChild[Either]], LTT[RoleParent[Either[Throwable, ?]]])
+      assertChild(LTT[RoleChild[Either]], LTT[RoleParent[Either[Throwable, *]]])
     }
 
     "support subtyping of parents parameterized with type lambdas in combined tags" in {
       val childBase = `LTT[_[_,_]]`[RoleChild]
       val childArg = `LTT[_,_]`[Either]
       val combinedTag = childBase.combine(childArg)
-      val expectedTag = LTT[RoleParent[Either[Throwable, ?]]]
+      val expectedTag = LTT[RoleParent[Either[Throwable, *]]]
 
       assertSame(combinedTag, LTT[RoleChild[Either]])
       assertChild(combinedTag, expectedTag)
@@ -198,7 +198,7 @@ class LightTypeTagTest extends TagAssertions {
       val childBase = `LTT[_[_,_],_,_]`[RoleChild2]
       val childArgs = Seq(`LTT[_,_]`[Either], LTT[Int], LTT[String])
       val combinedTag = childBase.combine(childArgs: _*)
-      val expectedTag = LTT[RoleParent[Either[Throwable, ?]]]
+      val expectedTag = LTT[RoleParent[Either[Throwable, *]]]
       val noncombinedTag = LTT[RoleChild2[Either, Int, String]]
 
       assertSame(combinedTag, noncombinedTag)
@@ -207,9 +207,9 @@ class LightTypeTagTest extends TagAssertions {
     }
 
     "support complex type lambdas" in {
-      assertSame(`LTT[_,_]`[NestedTL[Const, ?, ?]], `LTT[_,_]`[Lambda[(A, B) => FM2[(B, A)]]])
-      assertSame(`LTT[_[_]]`[NestedTL2[W1, W2, ?[_]]], `LTT[_[_]]`[Lambda[G[_] => FM2[G[S[W2, W1]]]]])
-      assertChild(`LTT[_,_]`[NestedTL[Const, ?, ?]], `LTT[_,_]`[Lambda[(A, B) => FM2[(B, A)]]])
+      assertSame(`LTT[_,_]`[NestedTL[Const, *, *]], `LTT[_,_]`[Lambda[(A, B) => FM2[(B, A)]]])
+      assertSame(`LTT[_[_]]`[NestedTL2[W1, W2, *[_]]], `LTT[_[_]]`[Lambda[G[_] => FM2[G[S[W2, W1]]]]])
+      assertChild(`LTT[_,_]`[NestedTL[Const, *, *]], `LTT[_,_]`[Lambda[(A, B) => FM2[(B, A)]]])
     }
 
     "support TagK* family summoners" in {
@@ -385,8 +385,8 @@ class LightTypeTagTest extends TagAssertions {
       assertChild(LTT[Set[Int]].typeArgs.head, LTT[collection.Set[AnyVal]].typeArgs.head)
 
       assert(`LTT[_,_]`[Either].typeArgs.isEmpty)
-      assert(`LTT[_]`[Either[String, ?]].typeArgs == List(LTT[String]))
-      assert(`LTT[_[_]]`[T0[List, ?[_]]].typeArgs == List(`LTT[_]`[List]))
+      assert(`LTT[_]`[Either[String, *]].typeArgs == List(LTT[String]))
+      assert(`LTT[_[_]]`[T0[List, *[_]]].typeArgs == List(`LTT[_]`[List]))
     }
 
     "support subtyping of a simple combined type" in {

--- a/izumi-reflect/izumi-reflect/src/test/scala_2/izumi/reflect/test/TagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_2/izumi/reflect/test/TagTest.scala
@@ -260,7 +260,7 @@ class TagTest extends AnyWordSpec with XY[String] {
     "Work for an abstract type with available TagKK" in {
       def t1[F[_, _]: TagKK, T: Tag, G: Tag] = Tag[F[T, G]]
 
-      assert(t1[ZOBA[Int, ?, ?], Int, String].tag == fromRuntime[ZOBA[Int, Int, String]])
+      assert(t1[ZOBA[Int, *, *], Int, String].tag == fromRuntime[ZOBA[Int, Int, String]])
     }
 
     "Handle Tags outside of a predefined set" in {
@@ -286,8 +286,8 @@ class TagTest extends AnyWordSpec with XY[String] {
       type ZOB[A, B, C] = Either[B, C]
 
       assert(
-        t1[Int, Boolean, ZOB[Unit, Int, Int], TagK[Option], Nothing, ZOB[Unit, Int, ?]].tag
-        == fromRuntime[T1[Int, Boolean, Either[Int, Int], TagK[Option], Nothing, Either[Int, ?]]]
+        t1[Int, Boolean, ZOB[Unit, Int, Int], TagK[Option], Nothing, ZOB[Unit, Int, *]].tag
+        == fromRuntime[T1[Int, Boolean, Either[Int, Int], TagK[Option], Nothing, Either[Int, *]]]
       )
 
       def t2[A: Tag, dafg: Tag, adfg: Tag, LS: Tag, L[_]: TagK, SD: Tag, GG[A] <: L[A]: TagK, ZZZ[_, _]: TagKK, S: Tag, SDD: Tag, TG: Tag]
@@ -406,57 +406,57 @@ class TagTest extends AnyWordSpec with XY[String] {
     }
 
     "resolve TagK from TagKK" in {
-      def getTag[F[+_, +_]: TagKK] = TagK[F[Throwable, ?]]
+      def getTag[F[+_, +_]: TagKK] = TagK[F[Throwable, *]]
       val tagEitherThrowable = getTag[Either].tag
-      val tag = TagK[Either[Throwable, ?]].tag
+      val tag = TagK[Either[Throwable, *]].tag
 
       assert(tagEitherThrowable =:= tag)
       assert(tagEitherThrowable <:< tag)
-      assert(tagEitherThrowable <:< TagK[Either[Any, ?]].tag)
-      assert(TagK[Either[Nothing, ?]].tag <:< tagEitherThrowable)
+      assert(tagEitherThrowable <:< TagK[Either[Any, *]].tag)
+      assert(TagK[Either[Nothing, *]].tag <:< tagEitherThrowable)
     }
 
     "can materialize TagK for type lambdas that close on a generic parameter with available Tag" in {
-      def partialEitherTagK[A: Tag] = TagK[Either[A, ?]]
+      def partialEitherTagK[A: Tag] = TagK[Either[A, *]]
 
       val tag = partialEitherTagK[Int].tag
-      val expectedTag = TagK[Either[Int, ?]].tag
+      val expectedTag = TagK[Either[Int, *]].tag
 
       assert(tag =:= expectedTag)
     }
 
     "can materialize TagK for type lambdas that close on a generic parameter with available Tag when the constructor is a type parameter" in {
-      def partialFTagK[F[_, _]: TagKK, A: Tag] = TagK[F[A, ?]]
+      def partialFTagK[F[_, _]: TagKK, A: Tag] = TagK[F[A, *]]
 
       val tag = partialFTagK[Either, Int].tag
-      val expectedTag = TagK[Either[Int, ?]].tag
+      val expectedTag = TagK[Either[Int, *]].tag
 
       assert(tag =:= expectedTag)
     }
 
     "type parameter covariance works after combine" in {
-      def getTag[F[+_, +_]: TagKK] = TagK[F[Throwable, ?]]
+      def getTag[F[+_, +_]: TagKK] = TagK[F[Throwable, *]]
       val tagEitherThrowable = getTag[Either].tag
-      val tagEitherSerializable = TagK[Either[java.io.Serializable, ?]]
+      val tagEitherSerializable = TagK[Either[java.io.Serializable, *]]
       assert(tagEitherThrowable <:< tagEitherSerializable.tag)
     }
 
     "combine Const Lambda to TagK" in {
-      def get[F[_, _]: TagKK] = TagK[F[Int, ?]]
+      def get[F[_, _]: TagKK] = TagK[F[Int, *]]
       val tag = get[Const]
 
-      assert(tag.tag =:= TagK[Const[Int, ?]].tag)
-      assert(tag.tag <:< TagK[Const[AnyVal, ?]].tag)
-      assert(tag.tag.hashCode() == TagK[Const[Int, ?]].tag.hashCode())
+      assert(tag.tag =:= TagK[Const[Int, *]].tag)
+      assert(tag.tag <:< TagK[Const[AnyVal, *]].tag)
+      assert(tag.tag.hashCode() == TagK[Const[Int, *]].tag.hashCode())
     }
 
     "combined TagK 3 & 2 parameter coherence" in {
-      def get[F[+_, +_]: TagKK] = TagK[F[Throwable, ?]]
+      def get[F[+_, +_]: TagKK] = TagK[F[Throwable, *]]
       val tag = get[IO]
 
-      assert(tag.tag =:= TagK[IO[Throwable, ?]].tag)
-      assert(tag.tag <:< TagK[IO[Throwable, ?]].tag)
-      assert(tag.tag <:< TagK[IO[Any, ?]].tag)
+      assert(tag.tag =:= TagK[IO[Throwable, *]].tag)
+      assert(tag.tag <:< TagK[IO[Throwable, *]].tag)
+      assert(tag.tag <:< TagK[IO[Any, *]].tag)
     }
 
     "resolve TagKK from an odd higher-kinded Tag with swapped & ignored parameters (low-level)" in {
@@ -477,24 +477,24 @@ class TagTest extends AnyWordSpec with XY[String] {
             None
           )
         ).tag
-      val expectedTag = TagKK[Lt[EitherRSwap, Throwable, ?, ?]].tag
+      val expectedTag = TagKK[Lt[EitherRSwap, Throwable, *, *]].tag
       assert(combinedTag =:= expectedTag)
     }
 
     "resolve TagKK from an odd higher-kinded Tag with swapped & ignored parameters" in {
-      def getTag[F[-_, +_, +_]: TagK3] = TagKK[F[?, ?, Throwable]]
+      def getTag[F[-_, +_, +_]: TagK3] = TagKK[F[*, *, Throwable]]
       val tagEitherSwap = getTag[EitherRSwap].tag
       val tagEitherThrowable = getTag[EitherR].tag
 
-      val expectedTagSwap = TagKK[EitherRSwap[?, ?, Throwable]].tag
-      val expectedTagEitherThrowable = TagKK[EitherR[?, ?, Throwable]].tag
+      val expectedTagSwap = TagKK[EitherRSwap[*, *, Throwable]].tag
+      val expectedTagEitherThrowable = TagKK[EitherR[*, *, Throwable]].tag
 
       assert(!(tagEitherSwap =:= expectedTagEitherThrowable))
       assert(tagEitherSwap =:= expectedTagSwap)
       assert(tagEitherThrowable =:= expectedTagEitherThrowable)
       assert(tagEitherSwap <:< expectedTagSwap)
-      assert(tagEitherSwap <:< TagKK[EitherRSwap[?, ?, Any]].tag)
-      assert(TagKK[EitherRSwap[?, ?, Nothing]].tag <:< tagEitherSwap)
+      assert(tagEitherSwap <:< TagKK[EitherRSwap[*, *, Any]].tag)
+      assert(TagKK[EitherRSwap[*, *, Nothing]].tag <:< tagEitherSwap)
     }
 
     "combine higher-kinded types without losing ignored type arguments" in {
@@ -505,7 +505,7 @@ class TagTest extends AnyWordSpec with XY[String] {
     }
 
     "resolve a higher-kinded type inside a named type lambda with ignored type arguments" in {
-      def mk[F[+_, +_]: TagKK] = Tag[BlockingIO3[F2To3[F, ?, ?, ?]]]
+      def mk[F[+_, +_]: TagKK] = Tag[BlockingIO3[F2To3[F, *, *, *]]]
       val tag = mk[IO]
 
       assert(tag.tag == Tag[BlockingIO[IO]].tag)
@@ -519,10 +519,10 @@ class TagTest extends AnyWordSpec with XY[String] {
     }
 
     "correctly resolve a higher-kinded nested type inside a named swap type lambda" in {
-      def mk[F[+_, +_]: TagKK] = Tag[BIOService[SwapF2[F, ?, ?]]]
+      def mk[F[+_, +_]: TagKK] = Tag[BIOService[SwapF2[F, *, *]]]
       val tag = mk[Either]
 
-      assert(tag.tag == Tag[BIOService[SwapF2[Either, ?, ?]]].tag)
+      assert(tag.tag == Tag[BIOService[SwapF2[Either, *, *]]].tag)
       assert(tag.tag == Tag[BIOService[Swap]].tag)
       assert(tag.tag == Tag[BIOService[Lambda[(E, A) => Either[A, E]]]].tag)
     }
@@ -531,7 +531,7 @@ class TagTest extends AnyWordSpec with XY[String] {
       def mk[F[+_, +_]: TagKK] = Tag[BIOService[Lambda[(E, A) => F[A, E]]]]
       val tag = mk[Either]
 
-      assert(tag.tag == Tag[BIOService[SwapF2[Either, ?, ?]]].tag)
+      assert(tag.tag == Tag[BIOService[SwapF2[Either, *, *]]].tag)
       assert(tag.tag == Tag[BIOService[Swap]].tag)
       assert(tag.tag == Tag[BIOService[Lambda[(E, A) => Either[A, E]]]].tag)
     }


### PR DESCRIPTION
There are a lot of kind-projector warnings. Seemed a quick fix.