### PR TITLE
Re-enable optimistic equality for 1.1.0 series

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -328,6 +328,7 @@ object LightTypeTag {
       other match {
         case that: ParsedLightTypeTag110 =>
           if (refString == that.refString) true
+          else if (optimisticEqualsEnabled) false
           else super.equals(other)
         case _ =>
           super.equals(other)


### PR DESCRIPTION
Somehow I disabled it without noticing in #157 🙈