### PR TITLE
Fix ParsedLightTypeTag110 hashCode

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -52,8 +52,8 @@ abstract class LightTypeTag(
 
   def ref: LightTypeTagRef
 
-  private[macrortti] lazy val basesdb: Map[AbstractReference, Set[AbstractReference]] = bases()
-  private[macrortti] lazy val idb: Map[NameReference, Set[NameReference]] = inheritanceDb()
+  private[reflect] lazy val basesdb: Map[AbstractReference, Set[AbstractReference]] = bases()
+  private[reflect] lazy val idb: Map[NameReference, Set[NameReference]] = inheritanceDb()
 
   @inline final def <:<(maybeParent: LightTypeTag): Boolean = {
     new LightTypeTagInheritance(this, maybeParent).isChild()

--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspect.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspect.scala
@@ -33,6 +33,6 @@ object Inspect {
       println(s"$dbs => ${strDbs.size} bytes, ${string2hex(strDbs)}")
       println(strDbs)
     }
-    '{ LightTypeTag.parse(${Expr(ref.hashCode())}, ${Expr(strRef)}, ${Expr(strDbs)}, ${Expr(LightTypeTag.currentBinaryFormatVersion)}) }
+    '{ LightTypeTag.parse(${Expr(ref.hashCode() * 31)}, ${Expr(strRef)}, ${Expr(strDbs)}, ${Expr(LightTypeTag.currentBinaryFormatVersion)}) }
   }
 }

--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspect.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspect.scala
@@ -14,25 +14,26 @@ object Inspect {
   inline def inspect[T <: AnyKind]: LightTypeTag = ${ inspectAny[T] }
 
   def inspectAny[T <: AnyKind: Type](using qctx: Quotes): Expr[LightTypeTag] = {
-    val ref = TypeInspections.apply[T]
-    val nameDb = TypeInspections.nameDb[T]
-    val fullDb = TypeInspections.fullDb[T]
-//    val ref = NameReference("xa")
-//    val nameDb = Map.empty[NameReference, Set[NameReference]] // FIXME: slowness is in nameDb, fullDb is fine
-//    val fullDb = Map.empty[AbstractReference, Set[AbstractReference]]
-    val dbs = SubtypeDBs(fullDb, nameDb)
-
-    val strRef = PickleImpl.serializeIntoString(ref, LightTypeTag.lttRefSerializer)
-    val strDbs = PickleImpl.serializeIntoString(dbs, LightTypeTag.subtypeDBsSerializer)
-
-    def string2hex(str: String): String = {
-        str.toList.map(_.toInt.toHexString).mkString
+    val res = {
+      val ref = TypeInspections.apply[T]
+      val fullDb = TypeInspections.fullDb[T]
+      val nameDb = TypeInspections.nameDb[T]
+      // val ref = NameReference("xa")
+      // val nameDb = Map.empty[NameReference, Set[NameReference]] // FIXME: slowness is in nameDb, fullDb is fine
+      // val fullDb = Map.empty[AbstractReference, Set[AbstractReference]]
+      LightTypeTag(ref, fullDb, nameDb)
     }
+
+    val hashCodeRef = res.hashCode()
+    val strRef = PickleImpl.serializeIntoString(res.ref, LightTypeTag.lttRefSerializer)
+    val strDbs = PickleImpl.serializeIntoString(SubtypeDBs(res.basesdb, res.idb), LightTypeTag.subtypeDBsSerializer)
+
     if (valueOf[InspectorBase#debug]) {
-      println(s"$ref => ${strRef.size} bytes, ${string2hex(strRef)}")
-      println(s"$dbs => ${strDbs.size} bytes, ${string2hex(strDbs)}")
+      def string2hex(str: String): String = str.toList.map(_.toInt.toHexString).mkString
+      println(s"${res.ref} => ${strRef.size} bytes, ${string2hex(strRef)}")
+      println(s"${SubtypeDBs(res.basesdb, res.idb)} => ${strDbs.size} bytes, ${string2hex(strDbs)}")
       println(strDbs)
     }
-    '{ LightTypeTag.parse(${Expr(ref.hashCode() * 31)}, ${Expr(strRef)}, ${Expr(strDbs)}, ${Expr(LightTypeTag.currentBinaryFormatVersion)}) }
+    '{ LightTypeTag.parse(${Expr(hashCodeRef)}, ${Expr(strRef)}, ${Expr(strDbs)}, ${Expr(LightTypeTag.currentBinaryFormatVersion)}) }
   }
 }

--- a/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/LightTypeTagTest.scala
@@ -503,5 +503,13 @@ class LightTypeTagTest extends TagAssertions {
 //        assertSame(tag, tag1)
 //      }
 //    }
+//
+    "calculate identical hashCode in parsed and constructed instances" in {
+      val tag1 = LTT[String]
+      val tag2 = tag1.withoutArgs
+      assertSameRef(tag1, tag2)
+      assertSame(tag1, tag2)
+      assert(tag1.hashCode() == tag2.hashCode())
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/zio/zio/issues/4739 / https://github.com/zio/zio/issues/4809

The `ParsedLightTypeTag110` instances generated by the Dotty macro in `dottyreflection/Inspect.scala` were using the ref hashCode directly while the `hashCode` function in `LightTypeTag.scala` has the following implementation:
```
private[this] lazy val hashcode: Int = {
  ref.hashCode() * 31
}
```
this made all `ParsedLightTypeTag110` instances fail `hashCode` comparisons with `LightTypeTag` instances on Dotty.

Scala 2 wasn't affected because the Scala 2 macro constructs a full `LightTypeTag` instance to delegate to its `hashCode` function:
```
final def makeParsedLightTypeTagImpl(tpe: Type): c.Expr[LightTypeTag] = {
    val res = impl.makeFullTagImpl(tpe)

    logger.log(s"LightTypeTagImpl: created LightTypeTag: $res")

    val hashCodeRef = res.hashCode()
    val strRef = PickleImpl.serializeIntoString(res.ref, LightTypeTag.lttRefSerializer)
    val strDBs = PickleImpl.serializeIntoString(SubtypeDBs(res.basesdb, res.idb), LightTypeTag.subtypeDBsSerializer)

    c.Expr[LightTypeTag](
      q"_root_.izumi.reflect.macrortti.LightTypeTag.parse($hashCodeRef: _root_.scala.Int, $strRef : _root_.java.lang.String, $strDBs : _root_.java.lang.String, ${LightTypeTag.currentBinaryFormatVersion}: _root_.scala.Int)"
    )
  }
```