### PR TITLE
Fix cached refined type issue (sorta)

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
@@ -92,7 +92,7 @@ abstract class Inspector(protected val shift: Int) extends InspectorBase {
         NameReference("???")
 
       // Matches CachedRefinedType for this ZIO issue https://github.com/zio/zio/issues/6071
-      case ref: Refined { def parent: TypeRepr } =>
+      case ref: Refinement =>
         next().inspectTypeRepr(ref.parent)
 
       case o =>

--- a/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala_3/izumi/reflect/dottyreflection/Inspector.scala
@@ -25,7 +25,7 @@ abstract class Inspector(protected val shift: Int) extends InspectorBase {
   }
 
   private[dottyreflection] def inspectTypeRepr(tpe: TypeRepr, outerTypeRef: Option[TypeRef] = None): AbstractReference = {
-    tpe.dealias match {
+    tpe.dealias.simplified match {
       case a: AnnotatedType =>
         inspectTypeRepr(a.underlying)
 
@@ -90,6 +90,10 @@ abstract class Inspector(protected val shift: Int) extends InspectorBase {
       case lazyref if lazyref.getClass.getName.contains("LazyRef") => // upstream bug seems like
         log(s"TYPEREPR UNSUPPORTED: LazyRef occured $lazyref")
         NameReference("???")
+
+      // Matches CachedRefinedType for this ZIO issue https://github.com/zio/zio/issues/6071
+      case ref: Refined { def parent: TypeRepr } =>
+        next().inspectTypeRepr(ref.parent)
 
       case o =>
         log(s"TYPEREPR UNSUPPORTED: $o")

--- a/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/TagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala_3/izumi/reflect/test/TagTest.scala
@@ -25,3 +25,34 @@ class TagTest extends SharedTagTest with TagAssertions {
   }
 
 }
+
+trait Layer[A] {
+  def tag: Tag[A]
+}
+
+object Layer {
+  def succeed[A: Tag](value: => A): Layer[A] =
+    new Layer[A] {
+      override def tag: Tag[A] = implicitly
+    }
+}
+
+// This should not fail to compile
+// Example from here: https://github.com/zio/zio/issues/6071
+object CachedRefinedTypeExample {
+
+  trait Animal
+  trait Dog extends Animal
+
+  trait Service {
+    def animal: Animal
+  }
+
+  val layer =
+    Layer.succeed {
+      new Service {
+        def animal: Dog = new Dog {}
+      }
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/zio/zio/issues/6071

Followed @neko-kai's recommendation. Not sure how dangerous it is 😄.
We're not handling structural/`Refined` types for Dotty at the moment it seems. This is A-Okay for zio's purposes at the moment, but just wanted to double check.

Seems like there might be a Dotty bug here as well, as trying to do `case r: Refined => r.tpt` blows up.