### PR TITLE
Fix partially #30 (only Scala 3)

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -43,8 +43,6 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
     typeRepr.dealias match {
       case x @ TypeRef(ThisType(_), _) if x.typeSymbol.isAbstractType && !x.typeSymbol.isClassDef => summonTag(x)
 
-      case x if x.typeSymbol.isTypeParam => summonTag(x)
-
       case AppliedType(ctor, args) =>
         val ctorTag = createTagExpr(ctor.asType)
         val argsTags = Expr.ofList(args.map(mkLtt))
@@ -64,6 +62,8 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
         val ltts0: List[Expr[LightTypeTag]] = flattenOr(orType).map(mkLtt)
         val ltts: Expr[List[LightTypeTag]] = Expr.ofList(ltts0)
         '{ Tag.unionTag[T](classOf[Any], $ltts) }
+
+      case x if x.typeSymbol.isTypeParam => summonTag(x)
 
       case _ =>
         throw new Exception(s"Unsupported type: $typeRepr")

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
@@ -23,6 +23,15 @@ class TagTest extends SharedTagTest with TagAssertions {
       assertNotChild(Tag[Animal | String].tag, Tag[Dog | String].tag)
     }
 
+    "Support HKTag for unapplied type lambdas with type bounds" in {
+      trait X
+      trait XAble[A <: X]
+      class Y extends X
+
+      def getTag[F[_ <: X]: Tag.auto.T] = Tag[F[Y]]
+
+      assertSame(getTag[XAble].tag, Tag[XAble[Y]].tag)
+    }
   }
 
 }


### PR DESCRIPTION
- I try to make Scala3 version Eff implementation
    - It will uses `Union` and higher kind types for effect stacks
- So I need this #30 , but I cannot fix this in Scala 2 😢 