### PR TITLE
Fix allPartsStrong

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -41,8 +41,9 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
 
   private def summonCombinedTag[T <: AnyKind: Type](typeRepr: TypeRepr): Expr[Tag[T]] =
     typeRepr.dealias match {
+      case x @ TypeRef(ThisType(_), _) if x.typeSymbol.isAbstractType && !x.typeSymbol.isClassDef => summonTag(x)
 
-      case x if x.typeSymbol.isTypeParam || x.typeSymbol.isAbstractType => summonTag(x)
+      case x if x.typeSymbol.isTypeParam => summonTag(x)
 
       case AppliedType(ctor, args) =>
         val ctorTag = createTagExpr(ctor.asType)
@@ -81,7 +82,8 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
     */
   private def allPartsStrong(typeRepr: TypeRepr): Boolean =
     typeRepr.dealias match {
-      case x if x.typeSymbol.isTypeParam || (x.typeSymbol.isAbstractType && !x.typeSymbol.isClassDef) => false
+      case x if x.typeSymbol.isTypeParam => false
+      case x @ TypeRef(ThisType(_), _) if x.typeSymbol.isAbstractType && !x.typeSymbol.isClassDef => false
       case AppliedType(tpe, args) => allPartsStrong(tpe) && args.forall(allPartsStrong)
       case AndType(lhs, rhs) => allPartsStrong(lhs) && allPartsStrong(rhs)
       case OrType(lhs, rhs) => allPartsStrong(lhs) && allPartsStrong(rhs)

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
@@ -5,6 +5,8 @@ import izumi.reflect.test.ID._
 
 class TagTest extends SharedTagTest with TagAssertions {
 
+  type Abstract
+
   override final val tagZ = Tag[String]
 
   "Tag (Dotty)" should {
@@ -21,6 +23,11 @@ class TagTest extends SharedTagTest with TagAssertions {
       assertChild(Tag[Dog].tag, Tag[Animal].tag)
       assertChild(Tag[Dog | String].tag, Tag[Animal | String].tag)
       assertNotChild(Tag[Animal | String].tag, Tag[Dog | String].tag)
+    }
+
+    "Does not synthesize Tags for abstract types, but recursively summons" in {
+      implicit val tag0: Tag[Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
+      val tag = Tag[Option[Abstract]]
     }
 
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
@@ -5,8 +5,6 @@ import izumi.reflect.test.ID._
 
 class TagTest extends SharedTagTest with TagAssertions {
 
-  type Abstract
-
   override final val tagZ = Tag[String]
 
   "Tag (Dotty)" should {
@@ -23,11 +21,6 @@ class TagTest extends SharedTagTest with TagAssertions {
       assertChild(Tag[Dog].tag, Tag[Animal].tag)
       assertChild(Tag[Dog | String].tag, Tag[Animal | String].tag)
       assertNotChild(Tag[Animal | String].tag, Tag[Dog | String].tag)
-    }
-
-    "Does not synthesize Tags for abstract types, but recursively summons" in {
-      implicit val tag0: Tag[Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
-      val tag = Tag[Option[Abstract]]
     }
 
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -309,16 +309,16 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
     assert(tag.tag.typeArgs.head == tag0.tag)
   }
 
-  "Does not synthesize Tags for abstract types, but recursively summons (object X; X.T)" in {
+  "DOES synthesize Tags for abstract types (object X; X.T)" in {
     implicit val tag0: Tag[SomeObject.Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
     val tag = Tag[Option[SomeObject.Abstract]]
-    assert(tag.tag.typeArgs.head == tag0.tag)
+    assert(tag.tag.typeArgs.head != tag0.tag)
   }
 
-  "Does not synthesize Tags for abstract types, but recursively summons (trait X; X#T)" in {
+  "DOES synthesize Tags for abstract types (trait X; X#T)" in {
     implicit val tag0: Tag[SomeTrait#Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
     val tag = Tag[Option[SomeTrait#Abstract]]
-    assert(tag.tag.typeArgs.head == tag0.tag)
+    assert(tag.tag.typeArgs.head != tag0.tag)
   }
 
 }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -58,6 +58,7 @@ trait T2[A, B, C[_[_], _], D[_], E]
 
 abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAssertions with InheritedModelKindProjector {
 
+  type Abstract
   type Swap[A, B] = Either[B, A]
   type SwapF2[F[_, _], A, B] = F[B, A]
   type Id[A] = A
@@ -302,4 +303,31 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
 
   }
 
+  "Does not synthesize Tags for abstract types, but recursively summons (this.Abstract)" in {
+    implicit val tag0: Tag[Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
+    val tag = Tag[Option[Abstract]]
+    assert(tag.tag.typeArgs.head == tag0.tag)
+  }
+
+  "Does not synthesize Tags for abstract types, but recursively summons (object X; X.T)" in {
+    implicit val tag0: Tag[SomeObject.Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
+    val tag = Tag[Option[SomeObject.Abstract]]
+    assert(tag.tag.typeArgs.head == tag0.tag)
+  }
+
+  "Does not synthesize Tags for abstract types, but recursively summons (trait X; X#T)" in {
+    implicit val tag0: Tag[SomeTrait#Abstract] = Tag.apply(Tag[Int].closestClass, Tag[Int].tag)
+    val tag = Tag[Option[SomeTrait#Abstract]]
+    assert(tag.tag.typeArgs.head == tag0.tag)
+  }
+
+}
+
+
+trait SomeTrait {
+  type Abstract
+}
+
+object SomeObject {
+  type Abstract
 }


### PR DESCRIPTION
@adamgfraser, @swoogles and I ran into a Tag issue with ZIO that stemmed from Tags being synthesized for abstract type members of traits, instead of being recursively summoned. This should (hopefully) fix that 😄 