### PR TITLE
Added Automatic-Module-Name to JAR manifest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,7 @@ lazy val `izumi-reflect-thirdparty-boopickle-shaded` = crossProject(JVMPlatform,
     // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
     Compile / packageBin / packageOptions +=
       Package.ManifestAttributes(
-        "Automatic-Module-Name" -> s"${organization.value.replaceAll("-",".")}.${moduleName.value.replaceAll("-",".")}"
+        "Automatic-Module-Name" -> s"${organization.value}.${moduleName.value}".replaceAll("-",".")
       )    
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -175,6 +175,14 @@ lazy val `izumi-reflect-thirdparty-boopickle-shaded` = crossProject(JVMPlatform,
     } },
     Compile / scalacOptions --= Seq("-Ywarn-value-discard","-Ywarn-unused:_", "-Wvalue-discard", "-Wunused:_")
   )
+  .settings(
+    // For compatibility with Java 9+ module system;
+    // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
+    Compile / packageBin / packageOptions +=
+      Package.ManifestAttributes(
+        "Automatic-Module-Name" -> s"${organization.value.replaceAll("-",".")}.${moduleName.value.replaceAll("-",".")}"
+      )    
+  )
   .jvmSettings(
     crossScalaVersions := Seq(
       "3.1.2",
@@ -384,6 +392,14 @@ lazy val `izumi-reflect` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       )
       case (_, _) => Seq.empty
     } }
+  )
+  .settings(
+    // For compatibility with Java 9+ module system;
+    // without Automatic-Module-Name, the module name is derived from the jar file which is invalid because of the scalaVersion suffix.
+    Compile / packageBin / packageOptions +=
+      Package.ManifestAttributes(
+        "Automatic-Module-Name" -> s"${organization.value.replaceAll("-",".")}.${moduleName.value.replaceAll("-",".")}"
+      )    
   )
   .jvmSettings(
     crossScalaVersions := Seq(


### PR DESCRIPTION
Fixes #289.

The module names are:
```
dev.zio.izumi.reflect
dev.zio.izumi.reflect.thirdparty.boopickle.shaded

```

All JAR artifacts passed the `jdeps --jdk-internals` [sanity check](http://branchandbound.net/blog/java/2017/12/automatic-module-name/).