### PR TITLE
Fix #133 return correct `closestClass` on Scala 3

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/Tags.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/Tags.scala
@@ -270,6 +270,5 @@ object WeakTag extends WeakTagInstances1 {
   implicit def weakTagFromTag[T <: AnyKind](implicit t: Tag[T]): WeakTag[T] = WeakTag(t.closestClass, t.tag)
 }
 trait WeakTagInstances1 {
-  // FIXME: weaken (disable allPartsStrong check for weak tag)
   implicit final def weakTagFromWeakTypeTag[T <: AnyKind](implicit l: LTag.Weak[T]): WeakTag[T] = WeakTag(classOf[Any], l.tag)
 }

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/ReflectionUtil.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/ReflectionUtil.scala
@@ -18,6 +18,19 @@ private[dottyreflection] trait ReflectionUtil { this: InspectorBase =>
       case _ => List(tpe)
     }
 
+  protected def intersectionUnionClassPartsOf(tpe: TypeRepr): List[TypeRepr] = {
+    tpe.dealias match {
+      case AndType(lhs, rhs) =>
+        intersectionUnionClassPartsOf(lhs) ++ intersectionUnionClassPartsOf(rhs)
+      case OrType(lhs, rhs) =>
+        intersectionUnionClassPartsOf(lhs) ++ intersectionUnionClassPartsOf(rhs)
+      case refinement: Refinement =>
+        intersectionUnionClassPartsOf(refinement.parent)
+      case _ =>
+        List(tpe)
+    }
+  }
+
   protected def allPartsStrong(typeRepr: TypeRepr): Boolean = {
     ReflectionUtil.allPartsStrong(using qctx)(shift, typeRepr)
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala
@@ -253,34 +253,6 @@ abstract class SharedTagProgressionTest extends AnyWordSpec with TagAssertions w
       }
     }
 
-    "progression test: Dotty fails to return expected class tag" in {
-      doesntWorkYetOnDotty {
-        assert(Tag[List[_] with Set[_]].closestClass eq classOf[scala.collection.immutable.Iterable[_]])
-      }
-      assert(!Tag[List[_] with Set[_]].hasPreciseClass)
-
-      assert(Tag[AnyVal].closestClass eq classOf[AnyVal])
-      assert(!Tag[AnyVal].hasPreciseClass)
-
-      doesntWorkYetOnDotty {
-        assert(Tag[String].closestClass ne classOf[AnyVal])
-      }
-      assert(!Tag[String with Int].hasPreciseClass)
-
-      doesntWorkYetOnDotty {
-        assert(Tag[List[Int]].closestClass eq classOf[List[_]])
-      }
-      doesntWorkYetOnDotty {
-        assert(Tag[List[Int]].hasPreciseClass)
-      }
-      doesntWorkYetOnDotty {
-        assert(Tag[H1].hasPreciseClass)
-      }
-
-      assert(Tag[ZY#T].closestClass eq classOf[Any])
-      assert(!Tag[ZY#T].hasPreciseClass)
-    }
-
     "progression test: Dotty fails to regression test: resolve correct closestClass for Scala vararg AnyVal (https://github.com/zio/izumi-reflect/issues/224)" in {
       doesntWorkYetOnDotty {
         assert(Tag[VarArgsAnyVal].closestClass == classOf[scala.Seq[Any]])

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.annotation.StaticAnnotation
+import scala.collection.immutable.List
 import scala.collection.mutable
 import scala.util.Try
 
@@ -618,6 +619,24 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
 
       assert(T1.tag =:= T3.tag)
       assert(T2.tag =:= T3.tag)
+    }
+
+    "return expected class tag" in {
+      assert(Tag[List[_] with Set[_]].closestClass eq classOf[scala.collection.immutable.Iterable[_]])
+      assert(!Tag[List[_] with Set[_]].hasPreciseClass)
+
+      assert(Tag[AnyVal].closestClass eq classOf[AnyVal])
+      assert(!Tag[AnyVal].hasPreciseClass)
+
+      assert(Tag[String].closestClass ne classOf[AnyVal])
+      assert(!Tag[String with Int].hasPreciseClass)
+
+      assert(Tag[List[Int]].closestClass eq classOf[List[_]])
+      assert(Tag[List[Int]].hasPreciseClass)
+      assert(Tag[H1].hasPreciseClass)
+
+      assert(Tag[ZY#T].closestClass eq classOf[Any])
+      assert(!Tag[ZY#T].hasPreciseClass)
     }
 
   }


### PR DESCRIPTION
Find most specific base class manually in lieu of `.lub` operator