### PR TITLE
Make collection-compat a Compile, not Provided dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -210,7 +210,7 @@ lazy val `izumi-reflect` = project.in(file("izumi-reflect/izumi-reflect"))
   .settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat % Provided
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat
     ),
     libraryDependencies ++= { if (scalaVersion.value.startsWith("2.")) Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
@@ -515,6 +515,7 @@ lazy val `izumi-reflect-root` = (project in file("."))
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef.longNameInternalSymbol"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef#AppliedNamedReference.symName"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef#AppliedNamedReference.prefix"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef.scalaStyledName"),
       ProblemFilters.exclude[Problem]("izumi.reflect.TagMacro.*"),
       ProblemFilters.exclude[Problem]("izumi.reflect.macrortti.LightTypeTagImpl.*"),
       ProblemFilters.exclude[Problem]("izumi.reflect.macrortti.LightTypeTagImpl#*"),

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -297,7 +297,7 @@ object Izumi {
       Artifact(
         name = Projects.izumi_reflect_aggregate.izumi_reflect,
         libs = Seq(
-          collection_compat in Scope.Provided.all
+          collection_compat in Scope.Compile.all
         ),
         depends = Seq(
           Projects.izumi_reflect_aggregate.thirdpartyBoopickleShaded


### PR DESCRIPTION
Downstream users must have collection-compat on the classpath to call macros