### PR TITLE
Fix 'weak' abstract type detection on Scala 3

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspect.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspect.scala
@@ -24,7 +24,8 @@ object Inspect {
   def inspectStrong[T <: AnyKind: Type](using qctx: Quotes): Expr[LightTypeTag] = {
     import qctx.reflect.*
     val tpe = TypeRepr.of[T]
-    if (ReflectionUtil.allPartsStrong(0, Set.empty, tpe)) {
+    val owners = ReflectionUtil.getClassDefOwners(Symbol.spliceOwner)
+    if (ReflectionUtil.allPartsStrong(0, owners, Set.empty, tpe)) {
       inspectAny[T]
     } else {
       report.errorAndAbort(s"Can't materialize LTag[$tpe]: found unresolved type parameters in $tpe")

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -966,9 +966,9 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
     }
 
     "regression test: do not be confused by a type alias of Set of an abstract type referred via this-prefix on Scala 3" in {
-      val t1 = Tag[RoleDep.RoleDeps["x", Int]].tag
-      val t2 = Tag[Set[RoleDep.RoleDep["x", Int]]].tag
-      val t3 = LTT[RoleDep.RoleDeps["x", Int]]
+      val t1 = Tag[RoleDep.RoleDeps[Int, Int]].tag
+      val t2 = Tag[Set[RoleDep.RoleDep[Int, Int]]].tag
+      val t3 = LTT[RoleDep.RoleDeps[Int, Int]]
 
       assertSameStrict(t1, t2)
       assertSameStrict(t1, t3)

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -965,6 +965,18 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       assert(t3InhBases.contains(tres1.tag.ref.withoutArgs.asInstanceOf[LightTypeTagRef.NameReference]))
     }
 
+    "regression test: do not be confused by a type alias of Set of an abstract type referred via this-prefix on Scala 3" in {
+      val t1 = Tag[RoleDep.RoleDeps["x", Int]].tag
+      val t2 = Tag[Set[RoleDep.RoleDep["x", Int]]].tag
+      val t3 = LTT[RoleDep.RoleDeps["x", Int]]
+
+      assertSameStrict(t1, t2)
+      assertSameStrict(t1, t3)
+
+      assertDebugSame(t1, t2)
+      assertDebugSame(t1, t3)
+    }
+
   }
 
 }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
@@ -192,4 +192,9 @@ object TestModel {
     type G[F[_], A] >: Unit <: T[F, A]
   }
 
+  object RoleDep {
+    type RoleDep[RoleId, C] >: Any
+    type RoleDeps[RoleId, C] = Set[this.RoleDep[RoleId, C]] // this-prefix is important, do not remove
+  }
+
 }


### PR DESCRIPTION
Work around https://github.com/lampepfl/dotty/issues/16107 - check if this-type prefix is present in the owner chain