### PR TITLE
Try to unify Scala 2 and 3 handling of tautological intersections, but fail because of https://github.com/lampepfl/dotty/issues/17544

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
@@ -561,7 +561,7 @@ class TagLambdaMacro(override val c: whitebox.Context) extends TagMacro(c) {
       case None =>
         c.abort(
           c.enclosingPosition,
-          "Couldn't find an the type that `Tag.auto.T` macro was applied to, please make sure you use the correct syntax, as in `def tagk[F[_]: Tag.auto.T]: TagK[T] = implicitly[Tag.auto.T[F]]`"
+          "Couldn't find the tree of the type that `Tag.auto.T` macro was applied to, please make sure you use the correct syntax, as in `def tagk[F[_]: Tag.auto.T]: TagK[T] = implicitly[Tag.auto.T[F]]`"
         )
       case Some(t) =>
         t

--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/Tags.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/Tags.scala
@@ -75,7 +75,7 @@ trait AnyTag extends Serializable {
   *   * Type Parameters do not yet resolve in structural refinement methods, e.g. T in {{{ Tag[{ def x: T}] }}}
   *     They do resolve in refinement type members however, e.g. {{{ Tag[ Any { type Out = T } ] }}}
   *   * TagK* does not resolve for constructors with bounded parameters, e.g. S in {{{ class Abc[S <: String]; TagK[Abc] }}}
-  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", ?]] }}}
+  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", _]] }}}
   *   * Further details at [[https://github.com/7mind/izumi/issues/374]]
   *
   * @see "Lightweight Scala Reflection and why Dotty needs TypeTags reimplemented" https://blog.7mind.io/lightweight-reflection.html

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/Tags.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/Tags.scala
@@ -75,7 +75,7 @@ trait AnyTag extends Serializable {
   *   * Type Parameters do not yet resolve in structural refinement methods, e.g. T in {{{ Tag[{ def x: T}] }}}
   *     They do resolve in refinement type members however, e.g. {{{ Tag[ Any { type Out = T } ] }}}
   *   * TagK* does not resolve for constructors with bounded parameters, e.g. S in {{{ class Abc[S <: String]; TagK[Abc] }}}
-  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", ?]] }}}
+  *     (You can still have a bound in partial application: e.g. {{{ class Abc[S <: String, A]; TagK[Abc["hi", _]] }}}
   *   * Further details at [[https://github.com/7mind/izumi/issues/374]]
   *
   * @see "Lightweight Scala Reflection and why Dotty needs TypeTags reimplemented" https://blog.7mind.io/lightweight-reflection.html

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
@@ -163,7 +163,7 @@ abstract class FullDbInspector(protected val shift: Int) extends InspectorBase {
     }
 
     private def inspectTypeBoundsToFull(tpe: TypeRepr): List[(AbstractReference, AbstractReference)] = {
-      tpe.dealias match {
+      tpe._dealiasSimplifiedFull match {
         case t: TypeBounds =>
           processTypeBounds(t)
         case t: TypeRepr =>

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/InheritanceDbInspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/InheritanceDbInspector.scala
@@ -20,7 +20,7 @@ abstract class InheritanceDbInspector(protected val shift: Int) extends Inspecto
   private lazy val inspector = Inspector.make(qctx)
 
   def makeUnappliedInheritanceDb[T <: AnyKind: Type]: Map[NameReference, Set[NameReference]] = {
-    val tpe0 = TypeRepr.of[T].dealias
+    val tpe0 = TypeRepr.of[T]._dealiasSimplifiedFull
 
     val allReferenceComponents = allTypeReferences(tpe0).filter {
       case _: ParamRef => false // do not process type parameters for inheritance db
@@ -71,7 +71,7 @@ abstract class InheritanceDbInspector(protected val shift: Int) extends Inspecto
   private def breakRefinement(tpe0: TypeRepr): collection.Set[TypeRepr] = {
     val tpes = mutable.HashSet.empty[TypeRepr]
 
-    def go(t0: TypeRepr): Unit = t0.dealias match {
+    def go(t0: TypeRepr): Unit = t0._dealiasSimplifiedFull match {
       case tpe: AndOrType =>
         go(tpe.left)
         go(tpe.right)

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
@@ -297,12 +297,20 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
     }
   }
 
-  private def flattenInspectAnd(and: AndType): Set[AppliedReference] = {
-    flattenAnd(and).toSet.map(inspectTypeRepr(_).asInstanceOf[AppliedReference])
+  private def flattenInspectAnd(and: AndType): Set[AppliedReferenceExceptIntersection] = {
+    flattenAnd(and).toSet.map(inspectTypeRepr(_)).flatMap {
+      case i: IntersectionReference => i.refs
+      case other: AppliedReferenceExceptIntersection => Set(other)
+      case _: LightTypeTagRef.Lambda => Set.empty
+    }
   }
 
-  private def flattenInspectOr(or: OrType): Set[AppliedReference] =
-    flattenOr(or).toSet.map(inspectTypeRepr(_).asInstanceOf[AppliedReference])
+  private def flattenInspectOr(or: OrType): Set[AppliedReferenceExceptUnion] =
+    flattenOr(or).toSet.map(inspectTypeRepr(_)).flatMap {
+      case i: UnionReference => i.refs
+      case other: AppliedReferenceExceptUnion => Set(other)
+      case _: LightTypeTagRef.Lambda => Set.empty
+    }
 
   private[dottyreflection] def makeNameReferenceFromType(t: TypeRepr): NameReference = {
     t match {

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
@@ -144,13 +144,13 @@ trait LTTRenderables extends Serializable with WithRenderableSyntax {
 
   implicit lazy val r_IntersectionReference: Renderable[IntersectionReference] = new Renderable[IntersectionReference] {
     override def render(value: IntersectionReference): String = {
-      value.refs.toSeq.sorted(OrderingAbstractReferenceInstance).map(_.render()).mkString("{", " & ", "}")
+      value.refs.toSeq.sorted(OrderingAbstractReferenceInstance).map(r => (r: AppliedReference).render()).mkString("{", " & ", "}")
     }
   }
 
   implicit lazy val r_UnionReference: Renderable[UnionReference] = new Renderable[UnionReference] {
     override def render(value: UnionReference): String = {
-      value.refs.toSeq.sorted(OrderingAbstractReferenceInstance).map(_.render()).mkString("{", " | ", "}")
+      value.refs.toSeq.sorted(OrderingAbstractReferenceInstance).map(r => (r: AppliedReference).render()).mkString("{", " | ", "}")
     }
   }
 

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -723,7 +723,7 @@ object LightTypeTag {
           if (ref.isDefined) state.enc.writeInt(-ref.get)
           else {
             state.enc.writeInt(0)
-            state.pickle[ArraySeqLike[LightTypeTagRef.AppliedReference]](LightTypeTagRef.refSetToSortedArray(value.refs))
+            state.pickle[ArraySeqLike[LightTypeTagRef.AppliedReference]](LightTypeTagRef.refSetToSortedArray[AppliedReference](value.refs))
             state.addIdentityRef(value)
           }
         }
@@ -755,7 +755,7 @@ object LightTypeTag {
           if (ref.isDefined) state.enc.writeInt(-ref.get)
           else {
             state.enc.writeInt(0)
-            state.pickle[ArraySeqLike[LightTypeTagRef.AppliedReference]](LightTypeTagRef.refSetToSortedArray(value.refs))
+            state.pickle[ArraySeqLike[LightTypeTagRef.AppliedReference]](LightTypeTagRef.refSetToSortedArray[AppliedReference](value.refs))
             state.addIdentityRef(value)
           }
         }

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -74,7 +74,18 @@ abstract class LightTypeTag private[reflect] (
 
   final def decompose: Set[LightTypeTag] = {
     ref match {
-      case LightTypeTagRef.IntersectionReference(refs) =>
+      case intersection: LightTypeTagRef.IntersectionReference =>
+        val refs = intersection.decompose // make sure to unwrap nested intersections
+        refs.map(LightTypeTag(_, basesdb, idb))
+      case _ =>
+        Set(this)
+    }
+  }
+
+  final def decomposeUnion: Set[LightTypeTag] = {
+    ref match {
+      case union: LightTypeTagRef.UnionReference =>
+        val refs = union.decomposeUnion // make sure to unwrap nested unions
         refs.map(LightTypeTag(_, basesdb, idb))
       case _ =>
         Set(this)
@@ -88,7 +99,7 @@ abstract class LightTypeTag private[reflect] (
     * lambda taking remaining arguments:
     *
     * {{{
-    *   F[?, ?, ?].combine(A, B) = F[A, B, ?]
+    *   F[_, _, _].combine(A, B) = F[A, B, _]
     * }}}
     */
   def combine(args: LightTypeTag*): LightTypeTag = {
@@ -117,7 +128,7 @@ abstract class LightTypeTag private[reflect] (
     * The resulting type lambda will take parameters in places where `args` was None:
     *
     * {{{
-    *   F[?, ?, ?].combine(Some(A), None, Some(C)) = F[A, ?, C]
+    *   F[_, _, _].combine(Some(A), None, Some(C)) = F[A, _, C]
     * }}}
     */
   def combineNonPos(args: Option[LightTypeTag]*): LightTypeTag = {
@@ -159,6 +170,62 @@ abstract class LightTypeTag private[reflect] (
     */
   def typeArgs: List[LightTypeTag] = {
     ref.typeArgs.map(LightTypeTag(_, basesdb, idb))
+  }
+
+  /**
+    * Remove types that are supertypes of other types in the intersection from it
+    *
+    * e.g. transform `Tag[TraitSuper & TraitChild & AnyRef]` to `Tag[TraitChild]`
+    */
+  def removeIntersectionTautologies: LightTypeTag = {
+    ref match {
+      case IntersectionReference(refs) =>
+        if (refs.size <= 1) {
+          this
+        } else {
+          refs.tail.foldLeft(LightTypeTag(refs.head, basesdb, idb)) {
+            case (acc, tref) =>
+              val t = LightTypeTag(tref, basesdb, idb)
+              if (t <:< acc) {
+                t
+              } else if (acc <:< t) {
+                acc
+              } else {
+                LightTypeTag(LightTypeTagRef.IntersectionReference(acc.ref.decompose + tref), basesdb, idb)
+              }
+          }
+        }
+      case _ =>
+        this
+    }
+  }
+
+  /**
+    * Remove types that are subtypes of other types in the union from it
+    *
+    * e.g. transform `Tag[TraitSuper | TraitChild | Nothing]` to `Tag[TraitSuper]`
+    */
+  def removeUnionTautologies: LightTypeTag = {
+    ref match {
+      case UnionReference(refs) =>
+        if (refs.size <= 1) {
+          this
+        } else {
+          refs.tail.foldLeft(LightTypeTag(refs.head, basesdb, idb)) {
+            case (acc, tref) =>
+              val t = LightTypeTag(tref, basesdb, idb)
+              if (t <:< acc) {
+                acc
+              } else if (acc <:< t) {
+                t
+              } else {
+                LightTypeTag(LightTypeTagRef.UnionReference(acc.ref.decomposeUnion + tref), basesdb, idb)
+              }
+          }
+        }
+      case _ =>
+        this
+    }
   }
 
   /** Render to string, omitting package names */
@@ -246,8 +313,7 @@ object LightTypeTag {
     * @param additionalTypeMembers additional type members
     */
   def refinedType(intersection: List[LightTypeTag], structure: LightTypeTag, additionalTypeMembers: Map[String, LightTypeTag]): LightTypeTag = {
-    val parts = intersection.iterator.flatMap(_.ref.decompose).toSet
-    val intersectionRef = LightTypeTagRef.maybeIntersection(parts)
+    val intersectionRef = LightTypeTagRef.maybeIntersection(intersection.iterator.map(_.ref))
     val ref = {
       val decls = structure.ref match {
         case LightTypeTagRef.Refinement(_, decls) if decls.nonEmpty =>
@@ -276,14 +342,13 @@ object LightTypeTag {
   }
 
   def unionType(union: List[LightTypeTag]): LightTypeTag = {
-    val parts = union.iterator.flatMap(_.ref.decomposeUnion).toSet
-    val ref = LightTypeTagRef.maybeUnion(parts)
+    val ref = LightTypeTagRef.maybeUnion(union.iterator.map(_.ref))
 
     def mergedBasesDB: Map[AbstractReference, Set[AbstractReference]] =
-      LightTypeTag.mergeIDBs(Map.empty[AbstractReference, Set[AbstractReference]], union.iterator.map(_.basesdb))
+      LightTypeTag.mergeIDBs(union.iterator.flatMap(_.basesdb))
 
     def mergedInheritanceDb: Map[NameReference, Set[NameReference]] =
-      LightTypeTag.mergeIDBs(Map.empty[NameReference, Set[NameReference]], union.iterator.map(_.idb))
+      LightTypeTag.mergeIDBs(union.iterator.flatMap(_.idb))
 
     LightTypeTag(ref, mergedBasesDB, mergedInheritanceDb)
   }
@@ -668,7 +733,12 @@ object LightTypeTag {
       override def unpickle(implicit state: boopickle.UnpickleState): LightTypeTagRef.UnionReference = {
         val ic = state.dec.readInt
         if (ic == 0) {
-          val value = LightTypeTagRef.UnionReference(state.unpickle[HashSet[LightTypeTagRef.AppliedReference]])
+          val refs0 = state.unpickle[HashSet[AppliedReference]]
+          val refs = refs0.flatMap {
+            case u: UnionReference => u.decomposeUnion
+            case other: AppliedReferenceExceptUnion => Set(other)
+          }
+          val value = LightTypeTagRef.UnionReference(refs)
           state.addIdentityRef(value)
           value
         } else if (ic < 0)
@@ -695,7 +765,12 @@ object LightTypeTag {
       override def unpickle(implicit state: boopickle.UnpickleState): LightTypeTagRef.IntersectionReference = {
         val ic = state.dec.readInt
         if (ic == 0) {
-          val value = LightTypeTagRef.IntersectionReference(state.unpickle[HashSet[LightTypeTagRef.AppliedReference]])
+          val refs0 = state.unpickle[HashSet[AppliedReference]]
+          val refs = refs0.flatMap {
+            case u: IntersectionReference => u.decompose
+            case other: AppliedReferenceExceptIntersection => Set(other)
+          }
+          val value = LightTypeTagRef.IntersectionReference(refs)
           state.addIdentityRef(value)
           value
         } else if (ic < 0)
@@ -998,17 +1073,19 @@ object LightTypeTag {
   }
 
   private[macrortti] def mergeIDBs[T](self: Map[T, Set[T]], other: Map[T, Set[T]]): Map[T, Set[T]] = {
-    import izumi.reflect.internal.fundamentals.collections.IzCollections._
-
-    val both = self.toSeq ++ other.toSeq
-    both.toMultimap.map {
-      case (k, v) =>
-        (k, v.flatten.filterNot(_ == k))
-    }
+    mergeIDBs(self.iterator ++ other.iterator)
   }
 
   private[macrortti] def mergeIDBs[T](self: Map[T, Set[T]], others: Iterator[Map[T, Set[T]]]): Map[T, Set[T]] = {
-    others.foldLeft(self)(mergeIDBs[T])
+    mergeIDBs(self.iterator ++ others.flatMap(_.iterator))
+  }
+
+  private[macrortti] def mergeIDBs[T](bases: Iterator[(T, Set[T])]): Map[T, Set[T]] = {
+    import izumi.reflect.internal.fundamentals.collections.IzCollections._
+    bases.toMultimap.map {
+      case (k, v) =>
+        (k, v.flatten.filterNot(_ == k))
+    }
   }
 
 }

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
@@ -31,8 +31,8 @@ import scala.collection.mutable
 object LightTypeTagInheritance {
   private[reflect] final val tpeNothing = NameReference(SymTypeName("scala.Nothing"))
   private[reflect] final val tpeAny = NameReference(SymTypeName("scala.Any"))
-  private[reflect] final val tpeAnyRef = NameReference(SymTypeName("scala.AnyRef"))
   private[reflect] final val tpeMatchable = NameReference(SymTypeName("scala.Matchable"))
+  private[reflect] final val tpeAnyRef = NameReference(SymTypeName("scala.AnyRef"))
   private[reflect] final val tpeObject = NameReference(SymTypeName(classOf[Object].getName))
 
   private final case class Ctx(

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
@@ -18,7 +18,6 @@
 
 package izumi.reflect.macrortti
 
-import izumi.reflect.internal.CollectionCompat
 import izumi.reflect.macrortti.LightTypeTagRef.{AbstractReference, AppliedReference}
 import izumi.reflect.macrortti.LightTypeTagRef.SymName.{LambdaParamName, SymTypeName}
 
@@ -152,8 +151,8 @@ object LightTypeTagRef extends LTTOrdering {
     LightTypeTagInheritance.tpeObject
   )
 
-  def maybeIntersection(refs0: CollectionCompat.IterableOnce[_ <: LightTypeTagRef]): AppliedReference = {
-    val refs = refs0.iterator.flatMap(_.decompose).toSet // flatten nested intersections
+  def maybeIntersection(refs0: Iterator[_ <: LightTypeTagRef]): AppliedReference = {
+    val refs = refs0.flatMap(_.decompose).toSet // flatten nested intersections
     if (refs.size == 1) {
       refs.head
     } else {
@@ -168,7 +167,7 @@ object LightTypeTagRef extends LTTOrdering {
     }
   }
 
-  def maybeUnion(refs0: CollectionCompat.IterableOnce[_ <: LightTypeTagRef]): AppliedReference = {
+  def maybeUnion(refs0: Iterator[_ <: LightTypeTagRef]): AppliedReference = {
     val refs = refs0.iterator.flatMap(_.decomposeUnion).toSet // flatten nested unions
     val normalized = refs - LightTypeTagInheritance.tpeNothing
     val superTypes = normalized.intersect(ignored)
@@ -190,8 +189,8 @@ object LightTypeTagRef extends LTTOrdering {
   }
 
   // bincompat
-  private[reflect] def maybeIntersection(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeIntersection(r: CollectionCompat.IterableOnce[_ <: LightTypeTagRef])
-  private[reflect] def maybeUnion(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeUnion(r: CollectionCompat.IterableOnce[_ <: LightTypeTagRef])
+  private[reflect] def maybeIntersection(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeIntersection(r.iterator)
+  private[reflect] def maybeUnion(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeUnion(r.iterator)
 
   sealed trait AppliedNamedReference extends AppliedReferenceExceptIntersection with AppliedReferenceExceptUnion {
     def asName: NameReference

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
@@ -188,9 +188,8 @@ object LightTypeTagRef extends LTTOrdering {
     }
   }
 
-  // bincompat
-  private[reflect] def maybeIntersection(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeIntersection(r.iterator)
-  private[reflect] def maybeUnion(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeUnion(r.iterator)
+  def maybeIntersection(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeIntersection(r.iterator)
+  def maybeUnion(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeUnion(r.iterator)
 
   sealed trait AppliedNamedReference extends AppliedReferenceExceptIntersection with AppliedReferenceExceptUnion {
     def asName: NameReference

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
@@ -18,7 +18,8 @@
 
 package izumi.reflect.macrortti
 
-import izumi.reflect.macrortti.LightTypeTagRef.AbstractReference
+import izumi.reflect.internal.CollectionCompat
+import izumi.reflect.macrortti.LightTypeTagRef.{AbstractReference, AppliedReference}
 import izumi.reflect.macrortti.LightTypeTagRef.SymName.{LambdaParamName, SymTypeName}
 
 import scala.runtime.AbstractFunction3
@@ -46,11 +47,11 @@ sealed trait LightTypeTagRef extends LTTSyntax with Serializable {
     "2.2.2"
   )
   final def longName: String = this.longNameInternalSymbolImpl
-  final def getPrefix: Option[LightTypeTagRef] = this.getPrefixImpl
+  final def getPrefix: Option[AppliedReference] = this.getPrefixImpl
   final def typeArgs: List[AbstractReference] = this.typeArgsImpl
   /** decompose intersection type */
-  final def decompose: Set[LightTypeTagRef.AppliedReference] = this.decomposeImpl
-  final def decomposeUnion: Set[LightTypeTagRef.AppliedReference] = this.decomposeUnionImpl
+  final def decompose: Set[LightTypeTagRef.AppliedReferenceExceptIntersection] = this.decomposeImpl
+  final def decomposeUnion: Set[LightTypeTagRef.AppliedReferenceExceptUnion] = this.decomposeUnionImpl
 
 }
 
@@ -117,17 +118,20 @@ object LightTypeTagRef extends LTTOrdering {
 
   sealed trait AppliedReference extends AbstractReference
 
-  final case class IntersectionReference(refs: Set[AppliedReference]) extends AppliedReference {
+  sealed trait AppliedReferenceExceptIntersection extends AppliedReference
+  sealed trait AppliedReferenceExceptUnion extends AppliedReference
+
+  final case class IntersectionReference(refs: Set[AppliedReferenceExceptIntersection]) extends AppliedReferenceExceptUnion {
     override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
   }
 
-  final case class WildcardReference(boundaries: Boundaries) extends AppliedReference
+  final case class WildcardReference(boundaries: Boundaries) extends AppliedReferenceExceptIntersection with AppliedReferenceExceptUnion
 
-  final case class UnionReference(refs: Set[AppliedReference]) extends AppliedReference {
+  final case class UnionReference(refs: Set[AppliedReferenceExceptUnion]) extends AppliedReferenceExceptIntersection {
     override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
   }
 
-  final case class Refinement(reference: AppliedReference, decls: Set[RefinementDecl]) extends AppliedReference {
+  final case class Refinement(reference: AppliedReference, decls: Set[RefinementDecl]) extends AppliedReferenceExceptIntersection with AppliedReferenceExceptUnion {
     override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
   }
 
@@ -140,14 +144,16 @@ object LightTypeTagRef extends LTTOrdering {
     }
   }
 
-  private[reflect] val ignored = Set[AppliedReference](
+  private[reflect] def ignored[T >: NameReference]: Set[T] = ignored0.asInstanceOf[Set[T]]
+  private[this] val ignored0: Set[NameReference] = Set[NameReference](
     LightTypeTagInheritance.tpeAny,
+    LightTypeTagInheritance.tpeMatchable,
     LightTypeTagInheritance.tpeAnyRef,
-    LightTypeTagInheritance.tpeObject,
-    LightTypeTagInheritance.tpeMatchable
+    LightTypeTagInheritance.tpeObject
   )
 
-  def maybeIntersection(refs: Set[AppliedReference]): AppliedReference = {
+  def maybeIntersection(refs0: CollectionCompat.IterableOnce[_ <: LightTypeTagRef]): AppliedReference = {
+    val refs = refs0.iterator.flatMap(_.decompose).toSet // flatten nested intersections
     if (refs.size == 1) {
       refs.head
     } else {
@@ -162,19 +168,32 @@ object LightTypeTagRef extends LTTOrdering {
     }
   }
 
-  def maybeUnion(refs: Set[AppliedReference]): AppliedReference = {
-    val normalized = refs.diff(ignored)
-    normalized.toList match {
-      case Nil =>
-        LightTypeTagInheritance.tpeAny
-      case head :: Nil =>
-        head
-      case _ =>
+  def maybeUnion(refs0: CollectionCompat.IterableOnce[_ <: LightTypeTagRef]): AppliedReference = {
+    val refs = refs0.iterator.flatMap(_.decomposeUnion).toSet // flatten nested unions
+    val normalized = refs - LightTypeTagInheritance.tpeNothing
+    val superTypes = normalized.intersect(ignored)
+    if (superTypes.nonEmpty) {
+      if (normalized.contains(LightTypeTagInheritance.tpeAny)) LightTypeTagInheritance.tpeAny
+      else if (normalized.contains(LightTypeTagInheritance.tpeMatchable)) LightTypeTagInheritance.tpeMatchable
+      else if (normalized.contains(LightTypeTagInheritance.tpeAnyRef)) LightTypeTagInheritance.tpeAnyRef
+      else if (normalized.contains(LightTypeTagInheritance.tpeObject)) LightTypeTagInheritance.tpeObject
+      else superTypes.head
+    } else {
+      if (normalized.isEmpty) {
+        LightTypeTagInheritance.tpeNothing
+      } else if (normalized.size == 1) {
+        normalized.head
+      } else {
         UnionReference(normalized)
+      }
     }
   }
 
-  sealed trait AppliedNamedReference extends AppliedReference {
+  // bincompat
+  private[reflect] def maybeIntersection(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeIntersection(r: CollectionCompat.IterableOnce[_ <: LightTypeTagRef])
+  private[reflect] def maybeUnion(r: Set[_ <: LightTypeTagRef]): AppliedReference = maybeUnion(r: CollectionCompat.IterableOnce[_ <: LightTypeTagRef])
+
+  sealed trait AppliedNamedReference extends AppliedReferenceExceptIntersection with AppliedReferenceExceptUnion {
     def asName: NameReference
     def symName: SymName
     def prefix: Option[AppliedReference]

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
@@ -168,7 +168,7 @@ object LightTypeTagRef extends LTTOrdering {
   }
 
   def maybeUnion(refs0: Iterator[_ <: LightTypeTagRef]): AppliedReference = {
-    val refs = refs0.iterator.flatMap(_.decomposeUnion).toSet // flatten nested unions
+    val refs = refs0.flatMap(_.decomposeUnion).toSet // flatten nested unions
     val normalized = refs - LightTypeTagInheritance.tpeNothing
     val superTypes = normalized.intersect(ignored)
     if (superTypes.nonEmpty) {

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/RuntimeAPI.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/RuntimeAPI.scala
@@ -132,10 +132,10 @@ object RuntimeAPI {
     private def replaceApplied(reference: AppliedReference): AbstractReference = {
       reference match {
         case IntersectionReference(refs) =>
-          val replaced = refs.map(replaceApplied).map(r => ensureApplied(reference, r))
+          val replaced = refs.map(replaceApplied).map(ensureApplied(reference, _))
           maybeIntersection(replaced)
         case UnionReference(refs) =>
-          val replaced = refs.map(replaceApplied).map(r => ensureApplied(reference, r))
+          val replaced = refs.map(replaceApplied).map(ensureApplied(reference, _))
           maybeUnion(replaced)
         case WildcardReference(boundaries) =>
           WildcardReference(replaceBoundaries(boundaries))

--- a/izumi-reflect/izumi-reflect/src/test/scala-2/izumi/reflect/test/TagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-2/izumi/reflect/test/TagProgressionTest.scala
@@ -1,6 +1,7 @@
 package izumi.reflect.test
 
 import izumi.reflect.Tag
+import org.scalatest.exceptions.TestFailedException
 
 class TagProgressionTest extends SharedTagProgressionTest {
 
@@ -36,6 +37,21 @@ class TagProgressionTest extends SharedTagProgressionTest {
         assertSameStrict(badCombine.tag, Tag[Int with Unit].tag)
       }
     }
+
+    "progression test: type tags with bounds are not currently requested by the macro on Scala 2" in {
+      val t = intercept[TestFailedException] {
+        assertCompiles(
+          """
+        type `TagK<:Dep`[K[_ <: Dep]] = izumi.reflect.HKTag[ { type Arg[A <: Dep] = K[A] } ]
+
+        def t[T[_ <: Dep]: `TagK<:Dep`, A <: Dep: Tag] = Tag[T[A]]
+
+        assert(t[Trait3, Dep].tag == Tag[Trait3[Dep]].tag)
+        """)
+      }
+      assert(t.message.get.contains("could not find implicit value"))
+    }
+
 
   }
 

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/LightTypeTagTest.scala
@@ -18,7 +18,8 @@
 
 package izumi.reflect.test
 
-import izumi.reflect.macrortti._
+import izumi.reflect.Tag
+import izumi.reflect.macrortti.*
 import izumi.reflect.macrortti.LightTypeTagRef.{AbstractReference, AppliedNamedReference, Boundaries, Lambda}
 
 import scala.collection.immutable.ListSet
@@ -33,6 +34,45 @@ class LightTypeTagTest extends SharedLightTypeTagTest {
     "tautological intersections with Matchable are discarded from internal structure (Scala 3 specific, Matchable)" in {
       assertSameStrict(LTT[Matchable with Option[String]], LTT[Option[String]])
       assertDebugSame(LTT[Matchable with Option[String]], LTT[Option[String]])
+    }
+
+    "tautological intersections with Matchable are discarded from internal structure (Scala 3 specific, Matchable) (Tag)" in {
+      assertSameStrict(Tag[Matchable with Option[String]].tag, LTT[Option[String]])
+      assertDebugSame(Tag[Matchable with Option[String]].tag, LTT[Option[String]])
+    }
+
+    "tautological unions with Any/AnyRef/Matchable/Object are discarded from internal structure (Scala 3 specific, Matchable)" in {
+      assertSameStrict(LTT[Any | Matchable | AnyRef | Object | Option[String] | Nothing], LTT[Any])
+      assertDebugSame(LTT[Any | Matchable | AnyRef | Object | Option[String] | Nothing], LTT[Any])
+
+      assertSameStrict(LTT[Matchable | AnyRef | Object | Option[String] | Nothing], LTT[Matchable])
+      assertDebugSame(LTT[Matchable | AnyRef | Object | Option[String] | Nothing], LTT[Matchable])
+
+      assertSameStrict(LTT[AnyRef | Object | Option[String] | Nothing], LTT[AnyRef])
+      assertDebugSame(LTT[AnyRef | Object | Option[String] | Nothing], LTT[AnyRef])
+
+      assertSameStrict(LTT[Object | Option[String] | Nothing], LTT[Object])
+      assertDebugSame(LTT[Object | Option[String] | Nothing], LTT[Object])
+
+      assertSameStrict(LTT[Option[String] | Nothing], LTT[Option[String]])
+      assertDebugSame(LTT[Option[String] | Nothing], LTT[Option[String]])
+    }
+
+    "tautological unions with Any/AnyRef/Matchable/Object are discarded from internal structure (Scala 3 specific, Matchable) (Tag)" in {
+      assertSameStrict(Tag[Any | Matchable | AnyRef | Object | Option[String] | Nothing].tag, LTT[Any])
+      assertDebugSame(Tag[Any | Matchable | AnyRef | Object | Option[String] | Nothing].tag, LTT[Any])
+
+      assertSameStrict(Tag[Matchable | AnyRef | Object | Option[String] | Nothing].tag, LTT[Matchable])
+      assertDebugSame(Tag[Matchable | AnyRef | Object | Option[String] | Nothing].tag, LTT[Matchable])
+
+      assertSameStrict(Tag[AnyRef | Object | Option[String] | Nothing].tag, LTT[AnyRef])
+      assertDebugSame(Tag[AnyRef | Object | Option[String] | Nothing].tag, LTT[AnyRef])
+
+      assertSameStrict(Tag[Object | Option[String] | Nothing].tag, LTT[Object])
+      assertDebugSame(Tag[Object | Option[String] | Nothing].tag, LTT[Object])
+
+      assertSameStrict(Tag[Option[String] | Nothing].tag, LTT[Option[String]])
+      assertDebugSame(Tag[Option[String] | Nothing].tag, LTT[Option[String]])
     }
 
     "support top-level abstract types (Scala 3 specific, top level type aliases)" in {

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagProgressionTest.scala
@@ -1,6 +1,7 @@
 package izumi.reflect.test
 
 import izumi.reflect.Tag
+import izumi.reflect.test.TestModel.*
 
 class TagProgressionTest extends SharedTagProgressionTest {
 
@@ -22,13 +23,48 @@ class TagProgressionTest extends SharedTagProgressionTest {
       def PDT[U: Tag]: PDT = new PDT { type T = U; override val tag: Tag[U] = Tag[U] }
 
       val badCombine = PDT[Int].badCombine(PDT[Unit])
-      doesntWorkYet {
+      doesntWorkYetOnDotty {
         assertSameStrict(badCombine.tag, Tag[Int with Unit].tag)
       }
 
       val goodCombine = PDT[Int].goodCombine(PDT[Unit])
-      doesntWorkYet {
+      doesntWorkYetOnDotty {
         assertSameStrict(goodCombine.tag, Tag[Int with Unit].tag)
+      }
+    }
+
+    // Can't fix this atm because simplification happens even without .simplified call because of https://github.com/lampepfl/dotty/issues/17544
+    "progression test: fails to don't lose tautological union components other than Nothing" in {
+      def tag1[T: Tag]: Tag[T | Trait1] = Tag[T | Trait1]
+      def tag4[T: Tag]: Tag[T | Trait4] = Tag[T | Trait4]
+
+      val t1 = tag1[Trait3[Dep]].tag
+      val t2 = tag4[Trait3[Dep]].tag
+
+      val t10 = Tag[Trait3[Dep] | Trait1].tag
+      val t20 = Tag[Trait3[Dep] | Trait4].tag
+
+      doesntWorkYetOnDotty {
+        assertSameStrict(t1, t10)
+        assertDebugSame(t1, t10)
+      }
+
+      assertSameStrict(t2, t20)
+      assertDebugSame(t2, t20)
+    }
+
+    // We don't really want to fix it, because removing tautologies is quadratic, with two subtyping comparisions per step!
+    // Would make construction really expensive, all for an extremely rare corner case
+    "progression test: union tautologies are not removed automatically when constructing combined union type" in {
+      def tag1[T: Tag]: Tag[T | Trait1] = Tag[T | Trait1]
+
+      val t1 = tag1[Trait3[Dep]].tag
+
+      val t10 = t1.removeUnionTautologies
+
+      doesntWorkYetOnDotty {
+        assertSameStrict(t1, t10)
+        assertDebugSame(t1, t10)
       }
     }
 

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/TagTest.scala
@@ -1,9 +1,11 @@
 package izumi.reflect.test
 
-import izumi.reflect.macrortti.LTag
+import izumi.reflect.macrortti.{LTT, LTag}
 import izumi.reflect.{HKTag, Tag, TagK, TagTK}
 import izumi.reflect.test.ID.*
 import izumi.reflect.test.PlatformSpecific.fromRuntime
+import izumi.reflect.test.TestModel.{Trait1, Trait3, Trait4}
+import org.scalatest.exceptions.TestFailedException
 
 class TagTest extends SharedTagTest with TagAssertions {
 
@@ -50,6 +52,22 @@ class TagTest extends SharedTagTest with TagAssertions {
       assertSameStrict(t2[Int, String].tag, Tag[String | Int].tag)
       assertSameStrict(t1[String].tag, Tag[String].tag)
       assertSameStrict(t2[String, String].tag, Tag[String].tag)
+    }
+
+    "type tags with bounds are successfully requested by TagMacro" in {
+      type `TagK<:Dep`[K[_ <: Dep]] = Tag.auto.T[K]
+
+      def t[T[_ <: Dep]: `TagK<:Dep`, A <: Dep: Tag] = Tag[T[A]]
+
+      assertSameStrict(t[Trait3, Dep].tag, Tag[Trait3[Dep]].tag)
+    }
+
+    "remove tautological unions with Nothing (LTT)" in {
+      assertSameStrict(LTT[Nothing | Option[String]], LTT[Option[String]])
+    }
+
+    "remove tautological unions with Nothing (Tag)" in {
+      assertSameStrict(Tag[Nothing | Option[String]].tag, LTT[Option[String]])
     }
 
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -56,10 +56,15 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       assertSameStrict(foo, bar)
     }
 
-    "eradicate tautologies with Any/Object" in {
-      assertSameStrict(LTT[Object with Option[String]], LTT[Option[String]])
+    "eradicate intersection tautologies with Any/Object" in {
       assertSameStrict(LTT[Any with Option[String]], LTT[Option[String]])
       assertSameStrict(LTT[AnyRef with Option[String]], LTT[Option[String]])
+      assertSameStrict(LTT[Object with Option[String]], LTT[Option[String]])
+    }
+
+    "do not eradicate intersections with Nothing" in {
+      assertDifferent(LTT[Nothing with Option[String]], LTT[Option[String]])
+      assertSameStrict(LTT[Nothing with Option[String]], LTT[Option[String] with Nothing])
     }
 
     "eradicate self-intersection (X with X)" in {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala
@@ -206,7 +206,7 @@ abstract class SharedTagProgressionTest extends AnyWordSpec with TagAssertions w
 
       val t10 = t1.removeIntersectionTautologies
 
-      doesntWorkYetOnDotty {
+      doesntWorkYet {
         assertSameStrict(t1, t10)
         assertDebugSame(t1, t10)
       }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -983,7 +983,6 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       val t2 = Tag[DiscoveryNodeProvider[NodeIdImpl]].tag
 
       assertSameStrict(t1, t2)
-
       assertDebugSame(t1, t2)
     }
 
@@ -1034,6 +1033,22 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       assertDifferent(t1.tag, Tag[Any].tag)
       assertSameStrict(t2.tag, Tag[RoleDep.RoleDeps[Int, String]].tag)
       assertDifferent(t2.tag, Tag[Any].tag)
+    }
+
+    "eradicate intersection tautologies with Any/Object (Tag)" in {
+      assertSameStrict(Tag[Any with Option[String]].tag, LTT[Option[String]])
+      assertSameStrict(Tag[AnyRef with Option[String]].tag, LTT[Option[String]])
+      assertSameStrict(Tag[Object with Option[String]].tag, LTT[Option[String]])
+    }
+
+    "tautological intersections with Any/Object are discarded from internal structure (Tag)" in {
+      assertSameStrict(Tag[(Object {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
+      assertSameStrict(Tag[(Any {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
+      assertSameStrict(Tag[(AnyRef {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
+
+      assertDebugSame(Tag[(Object {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
+      assertDebugSame(Tag[(Any {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
+      assertDebugSame(Tag[(AnyRef {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
     }
 
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
@@ -197,4 +197,14 @@ object TestModel {
     type RoleDeps[RoleId, C] = Set[this.RoleDep[RoleId, C]] // this-prefix is important, do not remove
   }
 
+  trait Trait1 {
+    def dep: Any
+  }
+
+  trait Trait3[T] extends Trait1 {
+    def dep: T
+  }
+
+  trait Trait4
+
 }


### PR DESCRIPTION
Try to unify Scala 2 and 3 handling of tautological intersections, but fail because of https://github.com/lampepfl/dotty/issues/17544

Add `removeIntersectionTautologies` and `removeUnionTautologies` methods to `LightTypeTag`

Ensure at type level that IntersectionReference and UnionReference can't be nested.

Fix maybeUnion not removing Nothing from unions and not widening to top types