### PR TITLE
Fix opacity of opaque types on Scala 3

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
@@ -258,8 +258,11 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
         makeNameReferenceFromSymbol(symbol, prefixSource)
 
       case s if s.isTypeDef =>
-        log(s"inspectSymbol: Found TypeDef symbol $s")
-        val rhs = s.typeRef._underlying
+        val rhs = outerTypeRef match {
+          case Some(r) if r.isOpaqueAlias => r._underlying
+          case _ => s.typeRef._underlying
+        }
+        log(s"inspectSymbol: Found TypeDef symbol $s (rhs=$rhs)")
         next().inspectTypeRepr(rhs, outerTypeRef)
 
       case s if s.isDefDef =>

--- a/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/LightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala-3/izumi/reflect/test/LightTypeTagTest.scala
@@ -79,6 +79,25 @@ class LightTypeTagTest extends SharedLightTypeTagTest {
       assertChildStrict(LTT[LightTypeTagTestT], LTT[String])
     }
 
+    "support opaque types" in {
+      object x {
+        type T >: List[Int] <: List[Int]
+        opaque type Opaque = List[Int]
+        opaque type OpaqueSub <: List[Int] = List[Int]
+      }
+
+      assertNotChildStrict(LTT[x.Opaque], LTT[List[Int]])
+      assertNotChildStrict(LTT[x.Opaque], LTT[Seq[Int]])
+      assertNotChildStrict(LTT[x.Opaque], LTT[x.T])
+      assertNotChildStrict(LTT[x.Opaque], LTT[x.OpaqueSub])
+
+      assertChildStrict(LTT[x.OpaqueSub], LTT[List[Int]])
+      assertChildStrict(LTT[x.OpaqueSub], LTT[Seq[Int]])
+      assertChildStrict(LTT[x.T], LTT[Seq[Int]])
+      assertChildStrict(LTT[x.OpaqueSub], LTT[x.T])
+      assertDifferent(LTT[x.OpaqueSub], LTT[x.T])
+    }
+
   }
 }
 


### PR DESCRIPTION
For `opaque type S = String` generate tag `S` instead of `S::<String..String>`

Breaks compatibility with previously generated tags for opaque types on Scala 3

/claim #472

lol lmao