### PR TITLE
Fix #469 while comparing Lambda check also if parameterized Parents inherits

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
@@ -146,7 +146,8 @@ final class LightTypeTagInheritance(self: LightTypeTag, other: LightTypeTag) {
         isChild(ctx.next())(s.output, t)
       case (s: Lambda, o: Lambda) =>
         (s.input.size == o.input.size
-        && isChild(ctx.next())(s.normalizedOutput, o.normalizedOutput))
+        && (isChild(ctx.next())(s.normalizedOutput, o.normalizedOutput)
+        || oneOfParameterizedParentsIsInheritedFrom(ctx)(s, o)))
 
       // intersections
       case (s: IntersectionReference, t: IntersectionReference) =>

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagProgressionTest.scala
@@ -89,11 +89,7 @@ abstract class SharedLightTypeTagProgressionTest extends TagAssertions with TagP
       // - λ %0,%1 → izumi.reflect.test.SharedLightTypeTagProgressionTest.KK2[+0,+1] ->
       //   * λ %0,%1 → izumi.reflect.test.SharedLightTypeTagProgressionTest.KK1[+1,+0,+scala.Unit]
 
-      brokenOnScala3 {
-//        withDebugOutput {
-        assertChild(`LTT[_]`[KK2[H2, *]], `LTT[_]`[KK1[*, H1, Unit]])
-//        }
-      }
+      assertChild(`LTT[_]`[KK2[H2, *]], `LTT[_]`[KK1[*, H1, Unit]])
     }
 
     "progression test: indirect structural checks do not work" in {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -542,6 +542,19 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       assert(tagEitherThrowable <:< tagEitherSerializable.tag)
     }
 
+    "regression test: https://github.com/zio/izumi-reflect/issues/469, indirect covariant comparison involving a higher-kinded type argument" in {
+      import TestModel._
+
+      trait Service[+O[_] <: Trait3[_]]
+      final case class AContainer[T](t: T) extends Trait3[T] {
+        override def dep = t
+      }
+      final case class ServiceImpl() extends Service[AContainer]
+
+      implicitly[ServiceImpl <:< Service[Trait3]]
+      assert(Tag[ServiceImpl] <:< Tag[Service[Trait3]])
+    }
+
     "combine Const Lambda to TagK" in {
       def get[F[_, _]: TagKK] = TagK[F[Int, *]]
       val tag = get[Const]


### PR DESCRIPTION
/close #469
/claim #469

This PR fixes Issue #469 by
- In lambda function, take in account parametrized parents
- adding test
