### PR TITLE
Fix #474 fix Array edge cases: Add missing .baseType call for Scala 3, skip erasure for subtypes of Scala 2 arrays

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
@@ -397,18 +397,24 @@ class TagMacro(val c: blackbox.Context) {
   @inline
   private[this] final def closestClass(properTypeStrongCtor: Type): c.Expr[Class[_]] = {
     // unfortunately .erasure returns trash for intersection types
-    val tpeLub = properTypeStrongCtor match {
+    val tpeLub = ReflectionUtil.norm(c.universe: c.universe.type, logger)(properTypeStrongCtor.dealias) match {
       case r: RefinedTypeApi => lub(r.parents)
-      case _ => properTypeStrongCtor
+      case o => o
     }
     val tpeErased = tpeLub.erasure
     // and for Scala varargs (Scala by names and Java varargs are fine)
     val tpeFixed = if (tpeErased.typeSymbol eq definitions.RepeatedParamClass) {
       typeOf[scala.Seq[Any]].dealias
+    } else if (tpeErased.typeSymbol eq definitions.ArrayClass) {
+      // workaround for a crash that happens when .erasure misfires on Array in case `Tag[Array[List[X]]]`
+      // and produces a tree `classOf[Array[List]]` which fails to compile.
+      // Array is the only type that needs to be parameterized after erasure and stripping its parameters via .erasure
+      // actually breaks it, so we skip this step for Arrays.
+      tpeLub.dealias
     } else {
       tpeErased
     }
-    c.Expr[Class[_]](q"_root_.scala.Predef.classOf[$tpeFixed]")
+    c.Expr[Class[_]](q"${Literal(Constant(tpeFixed))}.asInstanceOf[_root_.java.lang.Class[_]]")
   }
 
   @inline

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -34,7 +34,7 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
         // There's probably a missing case where a higher-kinded type is not a type lambda, with splicing inbetween causing fixup by the compiler
         //   val ltt = Inspect.inspectAny[A]
         val ltt = '{ Inspect.inspect[a] }
-        val cls = closestClassOfExpr(typeRepr)
+        val cls = closestClassOfTypeRepr(typeRepr)
         '{ Tag[a]($cls, $ltt) }.asInstanceOf[Expr[Tag[A]]]
     }
   }
@@ -159,7 +159,7 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
       case andType: AndType =>
         val tpes = flattenAnd(andType)
         val ltts: Expr[List[LightTypeTag]] = Expr.ofList(tpes.map(summonLTTAndFastTrackIfNotTypeParam))
-        val cls = Literal(ClassOfConstant(lubClassOf(tpes))).asExprOf[Class[?]]
+        val cls = Literal(ClassOfConstant(lubClassOf(typeReprDealiased, tpes))).asExprOf[Class[?]]
         val dummyAnyStructLtt = {
           // FIXME add constructor for intersections without the unused on Scala 3 struct type
           Inspect.inspectAny[Any]
@@ -169,12 +169,12 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
       case orType: OrType =>
         val tpes = flattenOr(orType)
         val ltts: Expr[List[LightTypeTag]] = Expr.ofList(tpes.map(summonLTTAndFastTrackIfNotTypeParam))
-        val cls = Literal(ClassOfConstant(lubClassOf(tpes))).asExprOf[Class[?]]
+        val cls = Literal(ClassOfConstant(lubClassOf(typeReprDealiased, tpes))).asExprOf[Class[?]]
         '{ Tag.unionTag[T](${ cls }, ${ ltts }) }
 
       case refinement: Refinement =>
         val (members, parent) = flattenRefinements(refinement)
-        val cls = closestClassOfExpr(parent)
+        val cls = closestClassOfTypeRepr(parent)
         val parentLtt = summonLTTAndFastTrackIfNotTypeParam(parent)
 
         val (allTypeMembers, termMembers) = members.partitionMap {
@@ -229,17 +229,23 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
     }
   }
 
-  private def closestClassOfExpr(typeRepr: TypeRepr): Expr[Class[?]] = {
-    Literal(ClassOfConstant(lubClassOf(intersectionUnionRefinementClassPartsOf(typeRepr)))).asExprOf[Class[?]]
+  private def closestClassOfTypeRepr(typeRepr: TypeRepr): Expr[Class[?]] = {
+    Literal(ClassOfConstant(lubClassOf(typeRepr, intersectionUnionRefinementClassPartsOf(typeRepr)))).asExprOf[Class[?]]
   }
 
-  private def lubClassOf(tpes: List[TypeRepr]): TypeRepr = {
+  private def lubClassOf(specificTpe: TypeRepr, tpes: List[TypeRepr]): TypeRepr = {
     tpes.map(_.baseClasses) match {
       case h :: t =>
         val bases = h.to(mutable.LinkedHashSet)
-        t.foreach(b => bases.filterInPlace(b.to(mutable.HashSet).contains))
+        t.foreach { b =>
+          val bBases = b.to(mutable.HashSet)
+          bases.filterInPlace(bBases)
+        }
         // rely on the fact that .baseClasses returns classes in order from most specific to least, therefore most specific class should be first.
-        bases.headOption.getOrElse(defn.AnyClass).typeRef
+        val baseClass = bases.headOption.getOrElse(defn.AnyClass)
+        // try to recover type parameters of the specific type e.g. to support Arrays
+        // see https://github.com/zio/izumi-reflect/issues/474 & https://github.com/scala/scala3/issues/21916
+        specificTpe.baseType(baseClass)
       // FIXME: below doesn't work, need to treat AnyVals specially
 //        bases.find(!_.typeRef.baseClasses.contains(defn.AnyValClass)).getOrElse(defn.AnyClass).typeRef
       case Nil =>

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -30,6 +30,7 @@ trait ZY extends Assertions {
   type U = T
   type V = List[T]
   type A = List[Option[Int]]
+  type O <: List[T]
   val x: String = "5"
   object y
   trait Y
@@ -649,15 +650,52 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
 
       assert(Tag[String].closestClass ne classOf[AnyVal])
       assert(!Tag[String with Int].hasPreciseClass)
+      assert(Tag[String with Int].closestClass eq classOf[Any])
 
-      assert(Tag[List[Int]].closestClass eq classOf[List[_]])
       assert(Tag[List[Int]].hasPreciseClass)
-      assert(Tag[H1].hasPreciseClass)
+      assert(Tag[List[Int]].closestClass eq classOf[List[_]])
 
-      assert(Tag[ZY#T].closestClass eq classOf[Any])
+      assert(Tag[H1].hasPreciseClass)
+      assert(Tag[H1].closestClass eq classOf[H1])
+
       assert(!Tag[ZY#T].hasPreciseClass)
+      assert(Tag[ZY#T].closestClass eq classOf[Any])
 
       assert(Tag[ZY#Y].hasPreciseClass)
+      assert(Tag[ZY#Y].closestClass eq classOf[ZY#Y])
+
+      assert(!Tag[ZY#O].hasPreciseClass)
+      assert(Tag[ZY#O].closestClass eq classOf[List[ZY#T]])
+
+      assert(Tag[Array[Byte]].closestClass eq classOf[Array[Byte]])
+      assert(Tag[Array[Int]].closestClass eq classOf[Array[Int]])
+      assert(Tag[Array[AnyRef]].closestClass eq classOf[Array[AnyRef]])
+      assert(Tag[Array[Boolean]].closestClass eq classOf[Array[Boolean]])
+      assert(Tag[Array[Char]].closestClass eq classOf[Array[Char]])
+      assert(Tag[Array[String]].closestClass eq classOf[Array[String]])
+      assert(Tag[Array[List[Any]]].closestClass eq classOf[Array[List[Any]]])
+
+      object test1 {
+        sealed trait TX0
+        class TX1 extends TX0
+        class TX2 extends TX0
+        class TX3 extends TX0
+
+        type OX[T] = TX1 with TX2 with T
+      }
+
+      assert(!Tag[test1.OX[ZY#Y]].hasPreciseClass)
+      assert(!Tag[test1.OX[test1.TX3]].hasPreciseClass)
+      assert(!Tag[test1.OX[test1.TX0]].hasPreciseClass)
+      assert(Tag[test1.OX[ZY#Y]].closestClass eq classOf[Any])
+      assert(Tag[test1.OX[test1.TX3]].closestClass eq classOf[test1.TX0])
+      assert(Tag[test1.OX[test1.TX0]].closestClass eq classOf[test1.TX0])
+
+      object test2 {
+        type ArrayT <: Array[Byte]
+      }
+      assert(!Tag[test2.ArrayT].hasPreciseClass)
+      assert(Tag[test2.ArrayT].closestClass eq classOf[Array[Byte]])
     }
 
     "Work with term type prefixes" in {
@@ -1049,6 +1087,10 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       assertDebugSame(Tag[(Object {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
       assertDebugSame(Tag[(Any {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
       assertDebugSame(Tag[(AnyRef {}) @IdAnnotation("x") with Option[(String with Object) {}]].tag, LTT[Option[String]])
+    }
+
+    "regression test for https://github.com/zio/izumi-reflect/issues/474" in {
+      assertCompiles("Tag[Array[Byte]]")
     }
 
   }


### PR DESCRIPTION
/claim #474