### PR TITLE
Fix Issue #31 TagMacro: resolve parameters inside type bounds & wildcards

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/ReflectionUtil.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/ReflectionUtil.scala
@@ -59,7 +59,7 @@ private[reflect] object ReflectionUtil {
       case e: Universe#ExistentialTypeApi =>
         allPartsStrong(outerTypeParams, e.underlying) &&
           e.underlying.typeArgs.forall(t => t.typeSymbol.typeSignature match {
-            case tb: Universe#TypeBounds => allPartsStrong(outerTypeParams, tb.hi) && allPartsStrong(outerTypeParams, tb.lo)
+            case tb: Universe#TypeBoundsApi => allPartsStrong(outerTypeParams, tb.hi) && allPartsStrong(outerTypeParams, tb.lo)
             case _ => allPartsStrong(outerTypeParams, t)
           } ) &&
           e.quantified.forall((s: Universe#Symbol) => allPartsStrong(outerTypeParams, s.asType.typeSignature.dealias))

--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/ReflectionUtil.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/ReflectionUtil.scala
@@ -56,6 +56,13 @@ private[reflect] object ReflectionUtil {
       case t: Universe#RefinedTypeApi =>
         t.parents.forall(allPartsStrong(outerTypeParams, _)) &&
         t.decls.toSeq.forall((s: Universe#Symbol) => s.isTerm || allPartsStrong(outerTypeParams, s.asType.typeSignature.dealias))
+      case e: Universe#ExistentialTypeApi =>
+        allPartsStrong(outerTypeParams, e.underlying) &&
+          e.underlying.typeArgs.forall(t => t.typeSymbol.typeSignature match {
+            case tb: Universe#TypeBounds => allPartsStrong(outerTypeParams, tb.hi) && allPartsStrong(outerTypeParams, tb.lo)
+            case _ => allPartsStrong(outerTypeParams, t)
+          } ) &&
+          e.quantified.forall((s: Universe#Symbol) => allPartsStrong(outerTypeParams, s.asType.typeSignature.dealias))
       case _ =>
         val resType = dealiased.finalResultType
         if (dealiased.takesTypeArgs && !dealiased.typeParams.forall(outerTypeParams.contains)) {

--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
@@ -373,16 +373,27 @@ class TagMacro(val c: blackbox.Context) {
             t =>
               if (exts.contains(t.typeSymbol)) {
                 /// generate top-level existential type for LightTypeTagImpl macro
-                c.internal.existentialType(List(t.typeSymbol), t)
+                t.typeSymbol.typeSignature match {
+                  case tb: TypeBounds =>
+                    val lo = tb.lo
+                    val hi = tb.hi
+                    val loTag = summonLightTypeTagOfAppropriateKind(lo)
+                    val hiTag = summonLightTypeTagOfAppropriateKind(hi)
+                    reify {
+                      LightTypeTag.wildcardType(loTag.splice, hiTag.splice)
+                    }
+                  case _ =>
+                    summonLightTypeTagOfAppropriateKind(c.internal.existentialType(List(t.typeSymbol), t))
+                }
               } else {
-                ReflectionUtil.norm(c.universe: c.universe.type, logger)(t.dealias)
+                summonLightTypeTagOfAppropriateKind(ReflectionUtil.norm(c.universe: c.universe.type, logger)(t.dealias))
               }
           }
         case _ =>
-          tpe.typeArgs.map(t => ReflectionUtil.norm(c.universe: c.universe.type, logger)(t.dealias))
+          tpe.typeArgs.map(t => summonLightTypeTagOfAppropriateKind(ReflectionUtil.norm(c.universe: c.universe.type, logger)(t.dealias)))
       }
       logger.log(s"Now summoning tags for args=$args")
-      c.Expr[List[LightTypeTag]](Liftable.liftList[c.Expr[LightTypeTag]].apply(args.map(summonLightTypeTagOfAppropriateKind)))
+      c.Expr[List[LightTypeTag]](Liftable.liftList[c.Expr[LightTypeTag]].apply(args))
     }
 
     {

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -48,8 +48,15 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
           case given Type[a] => '{ Inspect.inspect[a] }
         }
       } else {
-        val result = summonTag[T, Any](typeRepr)
-        '{ $result.tag }
+        typeRepr match {
+          case TypeBounds(low, high) =>
+            val lowTag = summonLTTAndFastTrackIfNotTypeParam(low)
+            val highTag = summonLTTAndFastTrackIfNotTypeParam(high)
+            '{ LightTypeTag.wildcardType( $lowTag, $highTag ) }
+          case _ =>
+            val result = summonTag[T, Any](typeRepr)
+            '{ $result.tag }
+        }
       }
     }
 

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -50,8 +50,8 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
       } else {
         typeRepr match {
           case TypeBounds(low, high) =>
-            val lowTag = summonCombinedTag(low)
-            val highTag = summonCombinedTag(high)
+            val lowTag = summonTagAndFastTrackIfNotTypeParam(low)
+            val highTag = summonTagAndFastTrackIfNotTypeParam(high)
             '{ LightTypeTag.wildcardType( $lowTag.tag, $highTag.tag ) }
           case _ =>
             val result = summonTag[T, Any](typeRepr)

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -50,9 +50,9 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
       } else {
         typeRepr match {
           case TypeBounds(low, high) =>
-            val lowTag = summonLTTAndFastTrackIfNotTypeParam(low)
-            val highTag = summonLTTAndFastTrackIfNotTypeParam(high)
-            '{ LightTypeTag.wildcardType( $lowTag, $highTag ) }
+            val lowTag = summonCombinedTag(low)
+            val highTag = summonCombinedTag(high)
+            '{ LightTypeTag.wildcardType( $lowTag.tag, $highTag.tag ) }
           case _ =>
             val result = summonTag[T, Any](typeRepr)
             '{ $result.tag }

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -354,7 +354,10 @@ object LightTypeTag {
   }
 
   def wildcardType(lowTag: LightTypeTag, highTag: LightTypeTag): LightTypeTag = {
-    val ref = LightTypeTagRef.WildcardReference(Boundaries.Defined(lowTag.ref.asInstanceOf[AbstractReference], highTag.ref.asInstanceOf[AbstractReference]))
+    val ref = LightTypeTagRef.WildcardReference(Boundaries.Defined(
+      lowTag.ref match { case r: AbstractReference => r },
+      highTag.ref match { case r: AbstractReference => r }
+    ))
 
     def mergedBasesDB: Map[AbstractReference, Set[AbstractReference]] =
       LightTypeTag.mergeIDBs(highTag.basesdb, lowTag.basesdb)

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -353,6 +353,18 @@ object LightTypeTag {
     LightTypeTag(ref, mergedBasesDB, mergedInheritanceDb)
   }
 
+  def wildcardType(lowTag: LightTypeTag, highTag: LightTypeTag): LightTypeTag = {
+    val ref = LightTypeTagRef.WildcardReference(Boundaries.Defined(lowTag.ref.asInstanceOf[AbstractReference], highTag.ref.asInstanceOf[AbstractReference]))
+
+    def mergedBasesDB: Map[AbstractReference, Set[AbstractReference]] =
+      LightTypeTag.mergeIDBs(highTag.basesdb, lowTag.basesdb)
+
+    def mergedInheritanceDb: Map[NameReference, Set[NameReference]] =
+      LightTypeTag.mergeIDBs(highTag.idb, lowTag.idb)
+      
+    LightTypeTag(ref, mergedBasesDB, mergedInheritanceDb)
+  }
+  
   def parse(serialized: Serialized): LightTypeTag = {
     parse[LightTypeTag](serialized.hash, serialized.ref, serialized.databases, serialized.version)
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -1099,10 +1099,15 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       def getLowerBoundTag[T: Tag] = Tag[Set[_ >: T]]
 
       assertRepr(getUpperBoundTag[Int].tag, "Set[=?: <Nothing..Int>]")
-      // was Set[=Int], should be Set[=?: <Nothing..Int>]
+      assertSame(getUpperBoundTag[Int].tag, Tag[Set[_ <: Int]].tag)
 
       assertRepr(getLowerBoundTag[Int].tag, "Set[=?: <Int..Any>]")
-      // was Set[=?: <T..Any>], should be Set[=?: <Int..Any>]
+      assertSame(getLowerBoundTag[Int].tag, Tag[Set[_ >: Int]].tag)
+
+      // for recursive bound case
+      def x[T[_]: TagK  , U: Tag] = Tag[Set[_ <: T[U]]]
+      assertRepr(x[List, Long].tag, "Set[=?: <Nothing..List[+Long]>]")
+      assertSame(x[List, Long].tag, Tag[Set[_ <: List[Long]]].tag)
     }
   }
 

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala
@@ -1093,6 +1093,17 @@ abstract class SharedTagTest extends AnyWordSpec with XY[String] with TagAsserti
       assertCompiles("Tag[Array[Byte]]")
     }
 
+    "resolve parameters inside type bounds & wildcards" in { // Issue #31
+      def getUpperBoundTag[T: Tag] = Tag[Set[_ <: T]]
+
+      def getLowerBoundTag[T: Tag] = Tag[Set[_ >: T]]
+
+      assertRepr(getUpperBoundTag[Int].tag, "Set[=?: <Nothing..Int>]")
+      // was Set[=Int], should be Set[=?: <Nothing..Int>]
+
+      assertRepr(getLowerBoundTag[Int].tag, "Set[=?: <Int..Any>]")
+      // was Set[=?: <T..Any>], should be Set[=?: <Int..Any>]
+    }
   }
 
 }


### PR DESCRIPTION
/claim #31  

I added new function wildcardType in LightTypeTag to create bounds wildcard type tag.

Also changed the TacMacro in scala 3 and scala 2 to parse the tag type bound parameters and summon the type tags accordingly 

Also fixed a bug in the scala 2 ReflectionUtil.scala that TypeBound's lower bound is not checked for strong type   