### PR TITLE
Fix regression in 3.0.0: properly dealias nested singletons on Scala 2

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -677,7 +677,7 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
 
         if (shouldDealias) {
           val dealiasedSym = Dealias.dealiasSingletons(sym)
-          val dealiasedTpe = sym.typeSignature.finalResultType
+          val dealiasedTpe = dealiasedSym.typeSignature.finalResultType
 
           (dealiasedSym, dealiasedTpe)
         } else (sym, tpe)

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -490,8 +490,8 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
 
       assertDifferent(LTT[A.Nested.Member], LTT[B.Nested.Member])
     }
-
-    "dealias nested singletons, regression test for singleton dealias regression introduced in 3.0.0 (https://github.com/zio/izumi-reflect/pull/504)" in {
+    // Workaround for https://github.com/scala/scala3/issues/23279
+    def dealiasTestWrapper(): Unit = {
       object lifecycle {
         object Lifecycle {
           trait FromZIO
@@ -503,6 +503,9 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       val xa: defn.Lifecycle.type = defn.Lifecycle
 
       assertSameStrict(LTT[xa.FromZIO], LTT[lifecycle.Lifecycle.FromZIO])
+    }
+    "dealias nested singletons, regression test for singleton dealias regression introduced in 3.0.0 (https://github.com/zio/izumi-reflect/pull/504)" in {
+      dealiasTestWrapper()
     }
 
     "properly dealias and assign prefixes to existential types and wildcards" in {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -491,6 +491,20 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       assertDifferent(LTT[A.Nested.Member], LTT[B.Nested.Member])
     }
 
+    "dealias nested singletons, regression test for singleton dealias regression introduced in 3.0.0 (https://github.com/zio/izumi-reflect/pull/504)" in {
+      object lifecycle {
+        object Lifecycle {
+          trait FromZIO
+        }
+      }
+      object defn {
+        val Lifecycle: lifecycle.Lifecycle.type = lifecycle.Lifecycle
+      }
+      val xa: defn.Lifecycle.type = defn.Lifecycle
+
+      assertSameStrict(LTT[xa.FromZIO], LTT[lifecycle.Lifecycle.FromZIO])
+    }
+
     "properly dealias and assign prefixes to existential types and wildcards" in {
       val withNothing = LTT[TestModel.With[Nothing]]
       val with_ = LTT[TestModel.With[_]]


### PR DESCRIPTION
Regression was introduced in https://github.com/zio/izumi-reflect/pull/504