### PR TITLE
Scala 2 & 3 Compile Time Caching with JMH Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Provided `flake.nix` can be used to set up the external dependencies necessary t
 nix develop
 ```
 
+Running benchmarks with JMH:
+
+```bash
+# Enable benchmarks in the build
+BENCHMARKS=true ./sbtgen.sc --js --native
+
+# Run benchmarks
+sbt izumi-reflect-benchmarks
+```
+
 <!--- docs:start --->
 
 # Talks

--- a/izumi-reflect/izumi-reflect/.jvm/src/benchmark/scala/izumi/reflect/benchmark/CacheBenchmark.scala
+++ b/izumi-reflect/izumi-reflect/.jvm/src/benchmark/scala/izumi/reflect/benchmark/CacheBenchmark.scala
@@ -1,0 +1,237 @@
+package izumi.reflect.benchmark
+
+import izumi.reflect.{DebugProperties, Tag}
+import izumi.reflect.macrortti.LTag
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms512m", "-Xmx512m", "-XX:+UseG1GC"))
+class CacheBenchmark {
+
+  @Param(Array("true", "false"))
+  var cacheEnabled: String = _
+
+  private var originalCacheProperty: String = _
+
+  @Setup(Level.Trial)
+  def setupTrial(): Unit = {
+    originalCacheProperty = System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`)
+    System.setProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`, cacheEnabled)
+
+    // Pre-warm the JVM and Tag caches (lightweight)
+    (1 to 100).foreach { _ =>
+      Tag[String].tag
+      Tag[Int].tag
+      LTag[List[String]].tag
+    }
+
+    System.gc()
+    Thread.sleep(50)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDownTrial(): Unit = {
+    if (originalCacheProperty != null) {
+      System.setProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`, originalCacheProperty)
+    } else {
+      System.clearProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`)
+    }
+  }
+
+  @Benchmark
+  def simpleTagCreation(bh: Blackhole): Unit = {
+    // Test full Tag creation (not just .tag access)
+    bh.consume(Tag[String])
+    bh.consume(Tag[Int])
+    bh.consume(Tag[Long])
+    bh.consume(Tag[Double])
+    bh.consume(Tag[Boolean])
+  }
+  
+  @Benchmark
+  def simpleTagAccess(bh: Blackhole): Unit = {
+    // Test tag access from cached Tags
+    bh.consume(Tag[String].tag)
+    bh.consume(Tag[Int].tag)
+    bh.consume(Tag[Long].tag)
+    bh.consume(Tag[Double].tag)
+    bh.consume(Tag[Boolean].tag)
+  }
+
+  @Benchmark
+  def complexTagCreation(bh: Blackhole): Unit = {
+    // Test full Tag creation for complex types
+    bh.consume(Tag[List[String]])
+    bh.consume(Tag[Map[String, Int]])
+    bh.consume(Tag[Either[String, Int]])
+    bh.consume(Tag[Option[List[String]]])
+    bh.consume(Tag[Vector[Map[String, Option[Int]]]])
+  }
+  
+  @Benchmark
+  def complexTagAccess(bh: Blackhole): Unit = {
+    // Test tag access from cached complex Tags
+    bh.consume(Tag[List[String]].tag)
+    bh.consume(Tag[Map[String, Int]].tag)
+    bh.consume(Tag[Either[String, Int]].tag)
+    bh.consume(Tag[Option[List[String]]].tag)
+    bh.consume(Tag[Vector[Map[String, Option[Int]]]].tag)
+  }
+
+  @Benchmark
+  def deeplyNestedTagCreation(bh: Blackhole): Unit = {
+    // Test full Tag creation for deeply nested types
+    bh.consume(Tag[Map[String, List[Either[Throwable, Option[Int]]]]])
+    bh.consume(Tag[List[Map[String, Either[Exception, Option[Long]]]]])
+    bh.consume(Tag[Either[List[String], Map[Int, Option[Double]]]])
+  }
+  
+  @Benchmark
+  def deeplyNestedTagAccess(bh: Blackhole): Unit = {
+    // Test tag access from cached deeply nested Tags
+    bh.consume(Tag[Map[String, List[Either[Throwable, Option[Int]]]]].tag)
+    bh.consume(Tag[List[Map[String, Either[Exception, Option[Long]]]]].tag)
+    bh.consume(Tag[Either[List[String], Map[Int, Option[Double]]]].tag)
+  }
+
+  @Benchmark
+  def hierarchyTagCreation(bh: Blackhole): Unit = {
+    // Define test types inline to avoid test dependencies
+    trait TestI1
+    trait TestI2 extends TestI1
+
+    bh.consume(Tag[String].tag)
+    bh.consume(Tag[TestI2].tag)
+    bh.consume(Tag[TestI1].tag)
+    bh.consume(Tag[AnyRef].tag)
+    bh.consume(Tag[Any].tag)
+    bh.consume(Tag[Object].tag)
+  }
+
+  @Benchmark
+  def ltagCreation(bh: Blackhole): Unit = {
+    // Test LTag creation (lightweight reference test)
+    bh.consume(LTag[String])
+    bh.consume(LTag[List[String]])
+    bh.consume(LTag[Map[String, Int]])
+    bh.consume(LTag[Either[String, Int]])
+  }
+
+  // Benchmarks addressing TODO: benchmark difference between searching all arguments vs. merge strategy
+  
+  @Benchmark
+  def allArgumentsSearchStrategy(bh: Blackhole): Unit = {
+    // Test Tag creation for types that require searching all type arguments
+    bh.consume(Tag[Map[String, List[Either[Int, String]]]])
+    bh.consume(Tag[Either[List[String], Map[Int, Option[Double]]]])
+    bh.consume(Tag[List[Map[String, Either[Exception, Option[Long]]]]])
+    bh.consume(Tag[Option[Either[List[String], Map[String, Int]]]])
+  }
+
+  @Benchmark
+  def mergeStrategySearch(bh: Blackhole): Unit = {
+    // Test Tag creation using merge strategy (simpler type combinations)
+    bh.consume(Tag[List[String]])
+    bh.consume(Tag[Map[String, Int]])
+    bh.consume(Tag[Either[String, Int]])
+    bh.consume(Tag[Option[String]])
+    bh.consume(Tag[Vector[Int]])
+  }
+
+  @Benchmark
+  def recursiveTypeResolution(bh: Blackhole): Unit = {
+    // Test complex recursive type parameter resolution
+    bh.consume(Tag[Map[List[String], Either[Option[Int], Vector[Double]]]])
+    bh.consume(Tag[Either[Map[String, List[Int]], Option[Vector[String]]]])
+    bh.consume(Tag[List[Either[Map[String, Int], Option[Vector[Boolean]]]]])
+  }
+
+  @Benchmark
+  def tagComparison(bh: Blackhole): Unit = {
+    val stringTag = Tag[String]
+    val intTag = Tag[Int]
+    val listStringTag = Tag[List[String]]
+    val mapStringIntTag = Tag[Map[String, Int]]
+
+    bh.consume(stringTag.tag =:= intTag.tag)
+    bh.consume(stringTag.tag =:= stringTag.tag)
+    bh.consume(listStringTag.tag =:= mapStringIntTag.tag)
+  }
+
+  @Benchmark
+  def subtypeChecking(bh: Blackhole): Unit = {
+    val childTags = Array(Tag[String], Tag[List[String]])
+    val parentTags = Array(Tag[Any], Tag[AnyRef])
+
+    var i = 0
+    while (i < childTags.length) {
+      var j = 0
+      while (j < parentTags.length) {
+        bh.consume(childTags(i).tag <:< parentTags(j).tag)
+        j += 1
+      }
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def tagCreationPatternComparison(bh: Blackhole): Unit = {
+    // Direct comparison of all three patterns on the same types
+    // ProviderMagnet pattern
+    bh.consume(implicitly[Tag[String]])
+    // Identity macro pattern  
+    bh.consume(Tag.apply[String])
+    // Direct construction pattern
+    bh.consume(Tag(classOf[String], LTag[String].tag))
+    
+    // Repeat for complex type
+    bh.consume(implicitly[Tag[List[String]]])
+    bh.consume(Tag.apply[List[String]])
+    bh.consume(Tag(classOf[scala.collection.immutable.List[_]], LTag[List[String]].tag))
+  }
+
+  // Benchmarks addressing TODO: benchmark ProviderMagnet vs. identity macro vs. normal function
+
+  @Benchmark
+  def providerMagnetPattern(bh: Blackhole): Unit = {
+    // Test implicit Tag summoning (ProviderMagnet pattern - uses implicit resolution)
+    bh.consume(implicitly[Tag[String]])
+    bh.consume(implicitly[Tag[List[String]]])
+    bh.consume(implicitly[Tag[Map[String, Int]]])
+    bh.consume(implicitly[Tag[Either[String, Int]]])
+    bh.consume(implicitly[Tag[Option[List[String]]]])
+  }
+
+  @Benchmark
+  def identityMacroPattern(bh: Blackhole): Unit = {
+    // Test direct macro invocation (identity macro pattern)
+    bh.consume(Tag.apply[String])
+    bh.consume(Tag.apply[List[String]])
+    bh.consume(Tag.apply[Map[String, Int]])
+    bh.consume(Tag.apply[Either[String, Int]])
+    bh.consume(Tag.apply[Option[List[String]]])
+  }
+
+  @Benchmark
+  def normalFunctionPattern(bh: Blackhole): Unit = {
+    // Test normal function calls (bypassing macros where possible)
+    val stringTag = Tag(classOf[String], LTag[String].tag)
+    val intTag = Tag(classOf[java.lang.Integer], LTag[Int].tag)
+    val booleanTag = Tag(classOf[java.lang.Boolean], LTag[Boolean].tag)
+    val longTag = Tag(classOf[java.lang.Long], LTag[Long].tag)
+    val doubleTag = Tag(classOf[java.lang.Double], LTag[Double].tag)
+    
+    bh.consume(stringTag)
+    bh.consume(intTag)
+    bh.consume(booleanTag)
+    bh.consume(longTag)
+    bh.consume(doubleTag)
+  }
+}
+

--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/TagMacro.scala
@@ -27,6 +27,7 @@ import izumi.reflect.macrortti.{LightTypeTag, LightTypeTagMacro0, LightTypeTagRe
 
 import scala.annotation.implicitNotFound
 import scala.collection.immutable.ListMap
+import scala.collection.concurrent.TrieMap
 import scala.reflect.api.Universe
 import scala.reflect.macros.{TypecheckException, blackbox, whitebox}
 
@@ -45,10 +46,27 @@ class TagMacro(val c: blackbox.Context) {
   // https://github.com/scala/bug/issues/11715
   final def makeTag[T: c.WeakTypeTag]: c.Expr[Tag[T]] = {
     val tpe = weakTypeOf[T]
-    if (ReflectionUtil.allPartsStrong(tpe.dealias)) {
-      makeStrongTagImpl[T](tpe, implicitly[c.WeakTypeTag[T]])
+    val tpeKey = tpe.dealias
+    
+    if (TagMacro.compileCacheEnabled) {
+      TagMacro.tagCache.get(tpeKey) match {
+        case Some(cached) =>
+          cached.asInstanceOf[c.Expr[Tag[T]]]
+        case None =>
+          val result = if (ReflectionUtil.allPartsStrong(tpe.dealias)) {
+            makeStrongTagImpl[T](tpe, implicitly[c.WeakTypeTag[T]])
+          } else {
+            makeWeakTagImpl[T](tpe, implicitly[c.WeakTypeTag[T]])
+          }
+          TagMacro.tagCache.putIfAbsent(tpeKey, result)
+          result
+      }
     } else {
-      makeWeakTagImpl[T](tpe, implicitly[c.WeakTypeTag[T]])
+      if (ReflectionUtil.allPartsStrong(tpe.dealias)) {
+        makeStrongTagImpl[T](tpe, implicitly[c.WeakTypeTag[T]])
+      } else {
+        makeWeakTagImpl[T](tpe, implicitly[c.WeakTypeTag[T]])
+      }
     }
   }
 
@@ -70,12 +88,31 @@ class TagMacro(val c: blackbox.Context) {
 
   @inline final def makeHKTag[ArgStruct: c.WeakTypeTag]: c.Expr[HKTag[ArgStruct]] = {
     val argStruct = weakTypeOf[ArgStruct]
-    val ctor = ltagMacro.unpackArgStruct(argStruct)
-    if (ReflectionUtil.allPartsStrong(ctor)) {
-      logger.log(s"HK: found Strong ctor=$ctor in ArgStruct, returning $argStruct")
-      makeHKTagFromStrongTpe[ArgStruct](ctor)
+    val argStructKey = argStruct.dealias
+    
+    if (TagMacro.compileCacheEnabled) {
+      TagMacro.hktagCache.get(argStructKey) match {
+        case Some(cached) =>
+          cached.asInstanceOf[c.Expr[HKTag[ArgStruct]]]
+        case None =>
+          val result = {
+            val ctor = ltagMacro.unpackArgStruct(argStruct)
+            if (ReflectionUtil.allPartsStrong(ctor)) {
+              makeHKTagFromStrongTpe[ArgStruct](ctor)
+            } else {
+              makeHKTagImpl(ctor, implicitly[c.WeakTypeTag[ArgStruct]])
+            }
+          }
+          TagMacro.hktagCache.putIfAbsent(argStructKey, result)
+          result
+      }
     } else {
-      makeHKTagImpl(ctor, implicitly[c.WeakTypeTag[ArgStruct]])
+      val ctor = ltagMacro.unpackArgStruct(argStruct)
+      if (ReflectionUtil.allPartsStrong(ctor)) {
+        makeHKTagFromStrongTpe[ArgStruct](ctor)
+      } else {
+        makeHKTagImpl(ctor, implicitly[c.WeakTypeTag[ArgStruct]])
+      }
     }
   }
 
@@ -574,6 +611,17 @@ class TagMacro(val c: blackbox.Context) {
 private object TagMacro {
   final val defaultTagImplicitError =
     "could not find implicit value for izumi.reflect.Tag[${T}]. Did you forget to put on a Tag, TagK or TagKK context bound on one of the parameters in ${T}? e.g. def x[T: Tag, F[_]: TagK] = ..."
+
+  private val tagCache = TrieMap.empty[Any, Any]
+  private val hktagCache = TrieMap.empty[Any, Any]
+  
+  /** caching is enabled by default for compile-time tag creation */
+  private val compileCacheEnabled: Boolean = {
+    import izumi.reflect.internal.fundamentals.platform.strings.IzString._
+    System
+      .getProperty(izumi.reflect.DebugProperties.`izumi.reflect.rtti.cache.compile`).asBoolean()
+      .getOrElse(true)
+  }
 
   final def tagFormatMap: Map[Kind, String] = {
     Map(

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -4,8 +4,10 @@ import scala.quoted.{Expr, Quotes, Type, Varargs}
 import izumi.reflect.macrortti.{LightTypeTag, LightTypeTagRef}
 import izumi.reflect.dottyreflection.{Inspect, InspectorBase, ReflectionUtil}
 import izumi.reflect.macrortti.LightTypeTagRef.{FullReference, NameReference, SymName, TypeParam, Variance}
+import izumi.reflect.DebugProperties
 
 import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 
 object TagMacro {
   def createTagExpr[A <: AnyKind: Type](using Quotes): Expr[Tag[A]] =
@@ -15,9 +17,37 @@ object TagMacro {
 final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
   import qctx.reflect._
 
+  private val tagCache = TrieMap.empty[String, Any]
+  
+  /** caching is enabled by default for compile-time tag creation */
+  private val compileCacheEnabled: Boolean = {
+    import izumi.reflect.internal.fundamentals.platform.strings.IzString._
+    System
+      .getProperty(izumi.reflect.DebugProperties.`izumi.reflect.rtti.cache.compile`).asBoolean()
+      .getOrElse(true)
+  }
+
   override def shift: Int = 0
 
   def createTagExpr[A <: AnyKind: Type]: Expr[Tag[A]] = {
+    val typeRepr = TypeRepr.of[A]._dealiasSimplifiedFull
+    val typeKey = typeRepr.show
+    
+    if (compileCacheEnabled) {
+      tagCache.get(typeKey) match {
+        case Some(cached) =>
+          cached.asInstanceOf[Expr[Tag[A]]]
+        case None =>
+          val result = createTagExprImpl[A]
+          tagCache.putIfAbsent(typeKey, result)
+          result
+      }
+    } else {
+      createTagExprImpl[A]
+    }
+  }
+
+  private def createTagExprImpl[A <: AnyKind: Type]: Expr[Tag[A]] = {
     val owners = getClassDefOwners(Symbol.spliceOwner)
     val typeRepr = TypeRepr.of[A]._dealiasSimplifiedFull
     if (allPartsStrong(owners, typeRepr)) {

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspect.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspect.scala
@@ -3,21 +3,54 @@ package izumi.reflect.dottyreflection
 import izumi.reflect.macrortti.LightTypeTag
 import izumi.reflect.macrortti.LightTypeTag.ParsedLightTypeTag.SubtypeDBs
 import izumi.reflect.thirdparty.internal.boopickle.PickleImpl
+import izumi.reflect.DebugProperties
+import izumi.reflect.internal.fundamentals.platform.strings.IzString._
 
 import scala.quoted.{Expr, Quotes, Type}
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.concurrent
+import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
 
 object Inspect {
+  
+  /** caching is enabled by default for compile-time light type tag creation */
+  private[this] lazy val compileCacheEnabled: Boolean = {
+    Option(System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`))
+      .map(_.toLowerCase != "false")
+      .getOrElse(true)
+  }
+  
+  private val compilationCache: concurrent.Map[String, (Expr[LightTypeTag], Int)] = 
+    new ConcurrentHashMap[String, (Expr[LightTypeTag], Int)]().asScala
   inline def inspect[T <: AnyKind]: LightTypeTag = ${ inspectAny[T] }
 
   inline def inspectStrong[T <: AnyKind]: LightTypeTag = ${ inspectStrong[T] }
 
   def inspectAny[T <: AnyKind: Type](using qctx: Quotes): Expr[LightTypeTag] = {
-    val ltt = {
-      val ref = TypeInspections.apply[T]
-      val fullDb = TypeInspections.fullDb[T]
-      val nameDb = TypeInspections.unappliedDb[T]
-      LightTypeTag(ref, fullDb, nameDb)
+    import qctx.reflect.*
+    
+    if (compileCacheEnabled) {
+      val tpe = TypeRepr.of[T]
+      val stableTypeKey = tpe.dealias.show(using Printer.TypeReprStructure)
+      
+      Inspect.compilationCache.get(stableTypeKey) match {
+        case Some(cached) if cached._2 == qctx.hashCode() =>
+          cached._1
+        case _ =>
+          val result = computeLightTypeTag[T]
+          Inspect.compilationCache.put(stableTypeKey, (result, qctx.hashCode()))
+          result
+      }
+    } else {
+      computeLightTypeTag[T]
     }
+  }
+  
+  private def computeLightTypeTag[T <: AnyKind: Type](using qctx: Quotes): Expr[LightTypeTag] = {
+    val ref = TypeInspections.apply[T]
+    val fullDb = TypeInspections.fullDb[T]
+    val nameDb = TypeInspections.unappliedDb[T]
+    val ltt = LightTypeTag(ref, fullDb, nameDb)
     makeParsedLightTypeTagImpl(ltt)
   }
 
@@ -31,6 +64,7 @@ object Inspect {
       report.errorAndAbort(s"Can't materialize LTag[$tpe]: found unresolved type parameters in $tpe")
     }
   }
+
 
   def makeParsedLightTypeTagImpl(ltt: LightTypeTag)(using qctx: Quotes): Expr[LightTypeTag] = {
     val serialized = ltt.serialize()

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
@@ -3,6 +3,8 @@ package izumi.reflect.dottyreflection
 import izumi.reflect.macrortti.{LightTypeTagInheritance, LightTypeTagRef}
 import izumi.reflect.macrortti.LightTypeTagRef.*
 import izumi.reflect.macrortti.LightTypeTagRef.SymName.SymTypeName
+import izumi.reflect.DebugProperties
+import izumi.reflect.internal.fundamentals.platform.strings.IzString._
 
 import scala.annotation.{tailrec, targetName}
 import scala.collection.immutable.Queue
@@ -10,6 +12,15 @@ import scala.quoted.{Quotes, Type}
 import scala.reflect.Selectable.reflectiveSelectable
 
 object Inspector {
+  private lazy val globalCache = new java.util.WeakHashMap[Any, AbstractReference]
+  
+  /** caching is enabled by default for compile-time light type tag creation */
+  private lazy val cacheEnabled: Boolean = {
+    System
+      .getProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`).asBoolean()
+      .getOrElse(true)
+  }
+
   case class LamParam(name: String, index: Int, depth: Int, arity: Int)(val qctx: Quotes)(val tpe: qctx.reflect.TypeRepr) {
     def asParam = SymName.LambdaParamName(index, depth, arity) // s"$depth:$index/$arity")
     // this might be useful for debugging
@@ -52,6 +63,22 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
   }
 
   private[dottyreflection] def inspectTypeRepr(tpe0: TypeRepr, outerTypeRef: Option[TypeRef] = None): AbstractReference = {
+    if (Inspector.cacheEnabled) {
+      val cacheKey = (tpe0, context.size, context.flatMap(_.params.map(_.name)).mkString(","))
+      Inspector.globalCache.synchronized(Inspector.globalCache.get(cacheKey)) match {
+        case null =>
+          val ref = inspectTypeReprImpl(tpe0, outerTypeRef)
+          Inspector.globalCache.synchronized(Inspector.globalCache.put(cacheKey, ref))
+          ref
+        case ref =>
+          ref
+      }
+    } else {
+      inspectTypeReprImpl(tpe0, outerTypeRef)
+    }
+  }
+
+  private def inspectTypeReprImpl(tpe0: TypeRepr, outerTypeRef: Option[TypeRef] = None): AbstractReference = {
     val tpe = tpe0._dealiasSimplifiedFull
 
     if (context.flatMap(_.params.map(_.tpe)).toSet.contains(tpe0)) {
@@ -68,7 +95,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
 
     tpe match {
       case a: AnnotatedType =>
-        inspectTypeRepr(a.underlying)
+        inspectTypeReprImpl(a.underlying)
 
       case appliedType: AppliedType =>
         val tycon: TypeRepr = appliedType.tycon._dealiasSimplifiedFull
@@ -106,12 +133,12 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
 
       case l: TypeLambda =>
         val inspector = nextLam(l)
-        val resType = inspector.inspectTypeRepr(l.resType)
+        val resType = inspector.inspectTypeReprImpl(l.resType)
         val paramNames = inspector.context.last.params.map(_.asParam)
         LightTypeTagRef.Lambda(paramNames, resType)
 
       case t: ThisType =>
-        next().inspectTypeRepr(t.tref)
+        next().inspectTypeReprImpl(t.tref)
 
       case a: AndType =>
         val elements = flattenInspectAnd(a)
@@ -161,11 +188,11 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
   private def inspectRefinements(ref: Refinement): AbstractReference = {
     val (refinements, nonRefinementParent) = flattenRefinements(ref)
 
-    val parentRef = next().inspectTypeRepr(nonRefinementParent)
+    val parentRef = next().inspectTypeReprImpl(nonRefinementParent)
 
     val refinementDecls = refinements.map {
       case (_, name, ByNameType(tpe)) => // def x(): Int
-        RefinementDecl.Signature(name, Nil, next().inspectTypeRepr(tpe).asInstanceOf[AppliedReference])
+        RefinementDecl.Signature(name, Nil, next().inspectTypeReprImpl(tpe).asInstanceOf[AppliedReference])
 
       case (_, name, m0: MethodOrPoly) => // def x(i: Int): Int; def x[A](a: A): A
         // FIXME as of version 2.3.0 RefinementDecl.Signature model is broken
@@ -184,8 +211,8 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
           }
         }
         val (inputTpes, resType) = squashMethodIgnorePolyType(m0)
-        val inputRefs = inputTpes.map(next().inspectTypeRepr(_).asInstanceOf[AppliedReference])
-        val outputRef = next().inspectTypeRepr(resType).asInstanceOf[AppliedReference]
+        val inputRefs = inputTpes.map(next().inspectTypeReprImpl(_).asInstanceOf[AppliedReference])
+        val outputRef = next().inspectTypeReprImpl(resType).asInstanceOf[AppliedReference]
         RefinementDecl.Signature(name, inputRefs, outputRef)
 
       case (_, name, bounds: TypeBounds) => // type T = Int
@@ -201,7 +228,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
         RefinementDecl.TypeMember(name, res)
 
       case (_, name, tpe) => // val t: Int
-        RefinementDecl.Signature(name, Nil, next().inspectTypeRepr(tpe).asInstanceOf[AppliedReference])
+        RefinementDecl.Signature(name, Nil, next().inspectTypeReprImpl(tpe).asInstanceOf[AppliedReference])
     }
 
     val ohOh = parentRef.asInstanceOf[AppliedReference]
@@ -244,8 +271,8 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
   }
 
   private def inspectBoundsImpl(tb: TypeBounds): Boundaries = {
-    val hi = next().inspectTypeRepr(tb.hi)
-    val low = next().inspectTypeRepr(tb.low)
+    val hi = next().inspectTypeReprImpl(tb.hi)
+    val low = next().inspectTypeReprImpl(tb.low)
     if (hi == LightTypeTagInheritance.tpeAny && low == LightTypeTagInheritance.tpeNothing) {
       Boundaries.Empty
     } else {
@@ -265,7 +292,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
           case _ => s.typeRef._underlying
         }
         log(s"inspectSymbol: Found TypeDef symbol $s (rhs=$rhs)")
-        next().inspectTypeRepr(rhs, outerTypeRef)
+        next().inspectTypeReprImpl(rhs, outerTypeRef)
 
       case s if s.isDefDef =>
         // We don't support method types, but if we do in the future,
@@ -286,7 +313,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
       case t: TypeBounds => // wildcard
         TypeParam(inspectBounds(outerTypeRef = None, tb = t), variance)
       case t: TypeRepr =>
-        TypeParam(inspectTypeRepr(t), variance)
+        TypeParam(inspectTypeReprImpl(t), variance)
     }
   }
 
@@ -306,7 +333,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
   }
 
   private def flattenInspectAnd(and: AndType): Set[AppliedReferenceExceptIntersection] = {
-    flattenAnd(and).toSet.map(inspectTypeRepr(_)).flatMap {
+    flattenAnd(and).toSet.map(inspectTypeReprImpl(_)).flatMap {
       case i: IntersectionReference => i.refs
       case other: AppliedReferenceExceptIntersection => Set(other)
       case _: LightTypeTagRef.Lambda => Set.empty
@@ -314,7 +341,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
   }
 
   private def flattenInspectOr(or: OrType): Set[AppliedReferenceExceptUnion] =
-    flattenOr(or).toSet.map(inspectTypeRepr(_)).flatMap {
+    flattenOr(or).toSet.map(inspectTypeReprImpl(_)).flatMap {
       case i: UnionReference => i.refs
       case other: AppliedReferenceExceptUnion => Set(other)
       case _: LightTypeTagRef.Lambda => Set.empty
@@ -420,7 +447,7 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
         if (!typeSymbol.exists || typeSymbol.isNoSymbol || typeSymbol.isPackageDef || typeSymbol.isDefDef || typeSymbol.isTypeDef || typeSymbol.isLocalDummy) {
           None
         } else {
-          inspectTypeRepr(prefix) match {
+          inspectTypeReprImpl(prefix) match {
             case reference: AppliedReference =>
               log(s"Constructed prefix=$reference from prefix=$prefix")
               Some(reference)

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -7,6 +7,7 @@ object Izumi {
   object V {
     val kind_projector = Version.VExpr("V.kind_projector")
     val scalatest = Version.VExpr("V.scalatest")
+    val jmh = Version.VExpr("V.jmh")
     val sbtgen = Version.VExpr("V.sbtgen")
   }
 
@@ -20,6 +21,14 @@ object Izumi {
     val scalajs_bundler_version = Version.VExpr("PV.scalajs_bundler_version")
     val sbt_mima_version = Version.VExpr("PV.sbt_mima_version")
     val zio_sbt_website = Version.VExpr("PV.zio_sbt_website")
+    val sbt_jmh = Version.VExpr("PV.sbt_jmh")
+  }
+
+  // Conditional benchmarks support - set with -Dbenchmarks=true or BENCHMARKS=true
+  lazy val benchmarksEnabled: Boolean = {
+    val sysProp = Option(System.getProperty("benchmarks")).map(_.toBoolean).getOrElse(false)
+    val envVar = Option(System.getenv("BENCHMARKS")).map(_.toBoolean).getOrElse(false)
+    sysProp || envVar
   }
 
   // DON'T REMOVE, these variables are read from CI build (build.sh)
@@ -70,6 +79,9 @@ object Izumi {
 
     final val projector = Library("org.typelevel", "kind-projector", V.kind_projector, LibraryType.Invariant)
       .more(LibSetting.Raw("cross CrossVersion.full"))
+
+    final val jmh_core = Library("org.openjdk.jmh", "jmh-core", V.jmh, LibraryType.Invariant)
+    final val jmh_generator = Library("org.openjdk.jmh", "jmh-generator-annprocess", V.jmh, LibraryType.Invariant)
   }
 
   import Deps._
@@ -330,10 +342,31 @@ object Izumi {
       ),
       Artifact(
         name = Projects.izumi_reflect_aggregate.izumi_reflect,
-        libs = Seq.empty,
+        libs = if (benchmarksEnabled) Seq(
+          ScopedLibrary(jmh_core, FullDependencyScope(Scope.Compile, Platform.Jvm)),
+          ScopedLibrary(jmh_generator, FullDependencyScope(Scope.Compile, Platform.Jvm))
+        ) else Seq.empty,
         depends = Seq(
           Projects.izumi_reflect_aggregate.thirdpartyBoopickleShaded
-        )
+        ),
+        settings = if (benchmarksEnabled) Seq(
+          SettingDef.RawSettingDef(
+            "Jmh / sourceDirectory := sourceDirectory.value / \"benchmark\"",
+            FullSettingScope(SettingScope.Raw("Jmh"), Platform.Jvm)
+          ),
+          SettingDef.RawSettingDef(
+            "Jmh / javaOptions ++= Seq(\"-server\", \"-Xms2g\", \"-Xmx2g\", \"-XX:+UseG1GC\", \"-XX:+UnlockExperimentalVMOptions\", \"-XX:+UnlockDiagnosticVMOptions\")",
+            FullSettingScope(SettingScope.Raw("Jmh"), Platform.Jvm)
+          ),
+          SettingDef.RawSettingDef(
+            "addCommandAlias(\"izumi-reflect-benchmarks\", \"izumi-reflectJVM/Jmh/run\")",
+            FullSettingScope(SettingScope.Build, Platform.All)
+          )
+        ) else Seq.empty,
+        plugins = if (benchmarksEnabled) Plugins(
+          enabled = Seq(Plugin("JmhPlugin")),
+          disabled = Seq.empty
+        ) else Plugins()
       )
     ),
     pathPrefix = Projects.izumi_reflect_aggregate.basePath,
@@ -371,6 +404,6 @@ object Izumi {
       SbtPlugin("org.scoverage", "sbt-scoverage", PV.sbt_scoverage),
       SbtPlugin("com.typesafe", "sbt-mima-plugin", PV.sbt_mima_version),
       SbtPlugin("dev.zio", "zio-sbt-website", PV.zio_sbt_website)
-    )
+    ) ++ (if (benchmarksEnabled) Seq(SbtPlugin("pl.project13.scala", "sbt-jmh", PV.sbt_jmh)) else Seq.empty)
   )
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,4 +19,5 @@
 object V {
   val kind_projector = "0.13.3"
   val scalatest = "3.2.19"
+  val jmh = "1.37"
 }

--- a/project/project/PluginVersions.scala
+++ b/project/project/PluginVersions.scala
@@ -32,4 +32,6 @@ object PV {
   val sbt_crossproject_version = "1.3.2"
 
   val zio_sbt_website = "0.4.0-alpha.31"
+  
+  val sbt_jmh = "0.4.7"
 }


### PR DESCRIPTION
Fixes https://github.com/zio/izumi-reflect/issues/350

The PR is ready for review:

1. I added JMH to the project. Need direction from the team on how benchmarks for everything else should be handled (dedicated repo?) I made sure it's conditional using the BENCHMARK=true flag when doing builds.

2. This is more a discussion based issue, but, it's possible to pre compute macros via TASTy with Scala 3 for more performance. This might be something different altogether, but, was worth bringing up for discussion.

3. This is my first PR, so I need broader general feedback on the styles and conventions on the diffs (and of course any potential errors or performance issues).

Looking forward to your feedback. Currently investigating TASTy to optimize macros further.