### PR TITLE
[WIP] ConcurrentHashMap Compile Time caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ Provided `flake.nix` can be used to set up the external dependencies necessary t
 nix develop
 ```
 
+## Benchmarks
+
+Compile with benchmarks:
+
+```bash
+./sbtgen.sc --js --native --benchmark
+```
+
+Run benchmarks:
+
+```bash
+sbt benchmarkCold
+sbt benchmarkWarm
+sbt benchmarkHot
+```
+
+Benchmark cache configurations:
+
+```bash
+sbt "izumi-reflect-benchmark/jmh:run HotTagCacheBenchmark -p cacheEnabled=true,false -p cacheMissPercentage=1,5,10"
+```
+
 <!--- docs:start --->
 
 # Talks

--- a/izumi-reflect/izumi-reflect-benchmark/src/main/scala-2/izumi/reflect/benchmark/TagCacheBenchmark.scala
+++ b/izumi-reflect/izumi-reflect-benchmark/src/main/scala-2/izumi/reflect/benchmark/TagCacheBenchmark.scala
@@ -1,0 +1,302 @@
+package izumi.reflect.benchmark
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.io.File
+import java.nio.file.{Files, Path}
+import java.util.concurrent.TimeUnit
+import scala.util.Try
+
+import scala.tools.nsc.{Global, Settings}
+import scala.tools.nsc.io.{AbstractFile, VirtualDirectory}
+import scala.tools.nsc.reporters.ConsoleReporter
+
+import izumi.reflect.Tag
+
+@State(Scope.Benchmark)
+class BaseTagCacheBenchmark {
+
+  @Param(Array("5", "10", "20"))
+  var cacheMissPercentage: Int = _
+
+  @Param(Array("50"))
+  var totalTagOperations: Int = _
+
+  @Param(Array("true", "false"))
+  var cacheEnabled: String = _
+
+  private var tempDir: Path = _
+  private var sourceFiles: List[String] = _
+  private var global: Global = _
+  private var uniqueId: String = _
+
+  @Setup(Level.Trial)
+  def setupTrial(): Unit = {
+    if (cacheEnabled == "false") {
+      System.setProperty("izumi.reflect.rtti.cache.compile", "false")
+    } else {
+      System.clearProperty("izumi.reflect.rtti.cache.compile")
+    }
+
+    val benchmarkId = s"cache-${cacheEnabled}-miss-${cacheMissPercentage}-ops-${totalTagOperations}"
+    tempDir = Files.createTempDirectory(s"izumi-reflect-benchmark-$benchmarkId")
+
+    val actualCacheSetting = Option(System.getProperty("izumi.reflect.rtti.cache.compile")).getOrElse("default(true)")
+    println(s"BENCHMARK: cache=$cacheEnabled, missRate=$cacheMissPercentage%, ops=$totalTagOperations, sysProp=$actualCacheSetting")
+  }
+
+  @Setup(Level.Iteration)
+  def setupIteration(): Unit = {
+    // Clear the global cache via reflection to ensure isolated iterations
+    clearGlobalCache()
+
+    if (cacheEnabled == "false") {
+      System.setProperty("izumi.reflect.rtti.cache.compile", "false")
+    } else {
+      System.clearProperty("izumi.reflect.rtti.cache.compile")
+    }
+    uniqueId = System.nanoTime().toHexString
+    sourceFiles = generateBenchmarkSources(tempDir, uniqueId)
+    initializeCompiler()
+  }
+
+  @TearDown(Level.Trial)
+  def tearDownTrial(): Unit = {
+    Try {
+      deleteRecursively(tempDir.toFile)
+    }
+  }
+
+  private def initializeCompiler(): Unit = {
+    val settings = new Settings()
+
+    settings.classpath.value = findIzumiReflectClasspath()
+    settings.usejavacp.value = true
+    settings.nopredef.value = false
+    settings.noimports.value = false
+
+    // Configure cache via -Xmacro-settings which the Scala 2 macro checks in c.settings
+    if (cacheEnabled == "false") {
+      settings.XmacroSettings.value = List("izumi.reflect.rtti.cache.compile=false")
+    } else {
+      settings.XmacroSettings.value = List()
+    }
+
+    val reporter = new ConsoleReporter(settings) {
+      override def displayPrompt(): Unit = ()
+    }
+    global = new Global(settings, reporter)
+  }
+
+  def compileImpl(blackhole: Blackhole): Unit = {
+    val iterationId = System.nanoTime()
+    val outputDir = new VirtualDirectory(s"output-$iterationId", None)
+
+    global.reporter.reset()
+    val compiler = global
+    val run = new compiler.Run()
+
+    val sources = sourceFiles.map { path =>
+      val file = AbstractFile.getFile(path)
+      file
+    }
+
+    Thread.sleep(1)
+
+    run.compile(sources.map(_.path))
+
+    if (compiler.reporter.hasErrors) {
+      throw new RuntimeException(s"Compilation failed: cache=$cacheEnabled, miss=$cacheMissPercentage%")
+    }
+
+    blackhole.consume(run)
+    blackhole.consume(outputDir.toString)
+    blackhole.consume(sources.length)
+    blackhole.consume(compiler.settings.classpath.value)
+  }
+
+  private def generateBenchmarkSources(srcDir: Path, uniqueId: String): List[String] = {
+    val missCount = (totalTagOperations * cacheMissPercentage) / 100
+    val hitCount = totalTagOperations - missCount
+
+    // Generate realistic domain models that would use izumi-reflect
+    val domainClasses = s"""
+  // Realistic domain models like you'd find in a large codebase
+  trait EventStore_${uniqueId}[F[_], Event]
+  trait EventHandler_${uniqueId}[F[_], Event, Result]
+  trait Repository_${uniqueId}[F[_], Entity, Id]
+  trait Service_${uniqueId}[F[_], Request, Response]
+  trait Cache_${uniqueId}[F[_], K, V]
+  trait Metrics_${uniqueId}[F[_]]
+  trait Logger_${uniqueId}[F[_]]
+
+  case class UserId_${uniqueId}(value: String) extends AnyVal
+  case class OrderId_${uniqueId}(value: String) extends AnyVal
+  case class ProductId_${uniqueId}(value: String) extends AnyVal
+
+  sealed trait UserEvent_${uniqueId}
+  case class UserCreated_${uniqueId}(id: UserId_${uniqueId}, email: String, timestamp: Long) extends UserEvent_${uniqueId}
+  case class UserUpdated_${uniqueId}(id: UserId_${uniqueId}, changes: Map[String, String], timestamp: Long) extends UserEvent_${uniqueId}
+  case class UserDeleted_${uniqueId}(id: UserId_${uniqueId}, timestamp: Long) extends UserEvent_${uniqueId}
+
+  case class User_${uniqueId}(id: UserId_${uniqueId}, email: String, profile: UserProfile_${uniqueId})
+  case class UserProfile_${uniqueId}(firstName: String, lastName: String, preferences: Map[String, String])
+  case class Order_${uniqueId}(id: OrderId_${uniqueId}, userId: UserId_${uniqueId}, status: OrderStatus_${uniqueId}, items: List[OrderItem_${uniqueId}])
+  case class OrderItem_${uniqueId}(productId: ProductId_${uniqueId}, quantity: Int, price: BigDecimal)
+
+  sealed trait OrderStatus_${uniqueId}
+  case object Pending_${uniqueId} extends OrderStatus_${uniqueId}
+  case object Processing_${uniqueId} extends OrderStatus_${uniqueId}
+  case object Shipped_${uniqueId} extends OrderStatus_${uniqueId}"""
+
+    // Generate unique types for cache misses
+    val uniqueTypes = (0 until missCount).map { i =>
+      s"""  case class UserEvent${i}_${uniqueId}(data: String) extends UserEvent_${uniqueId}
+  case class CreateRequest${i}_${uniqueId}(email: String, profile: UserProfile_${uniqueId})"""
+    }.mkString("\n")
+
+    // Generate cache miss tags - simple unique types
+    val cacheMissTagDefs = (0 until missCount).map { i =>
+      s"  val missTag$i = Tag[UserEvent${i}_${uniqueId}]"
+    }.mkString("\n")
+
+    // Generate cache hit tags - simple repeated types
+    val commonTypes = List(
+      s"User_${uniqueId}",
+      s"Order_${uniqueId}",
+      s"UserEvent_${uniqueId}",
+      s"OrderId_${uniqueId}"
+    )
+
+    val cacheHitTagDefs = (0 until hitCount).map { i =>
+      val commonType = commonTypes(i % commonTypes.length)
+      s"  val hitTag$i = Tag[$commonType]"
+    }.mkString("\n")
+
+
+    val sourceCode = s"""package izumi.reflect.benchmark.generated
+
+import izumi.reflect.Tag
+import scala.concurrent.Future
+import scala.math.BigDecimal
+import scala.util.Either
+
+object TagBenchmarkCode {""" + "\n" +
+      domainClasses + "\n\n" +
+      uniqueTypes + "\n\n" +
+      cacheMissTagDefs + "\n\n" +
+      cacheHitTagDefs + "\n\n" +
+      "  val allTags = Seq(" + "\n" +
+      (0 until missCount).map(i => s"    missTag$i").mkString(",\n") +
+      (if (missCount > 0 && hitCount > 0) ",\n" else "\n") +
+      (0 until hitCount).map(i => s"    hitTag$i").mkString(",\n") + "\n" +
+      "  )" + "\n\n" +
+      "  val tagData = allTags.map(_.tag.longNameWithPrefix)" + "\n" +
+      "  val tagUsage = tagData.zipWithIndex.map { case (name, idx) =>" + "\n" +
+      "    s\"${idx}_${name.hashCode}\"" + "\n" +
+      "  }.mkString(\",\")" + "\n\n" +
+      "  val tagCount = allTags.length" + "\n" +
+      "  val tagSample = if (allTags.nonEmpty) allTags.head.tag.longNameWithPrefix else \"none\"" + "\n" +
+      "}"
+
+    val outputFile = srcDir.resolve(s"TagBenchmarkCode_${uniqueId}.scala")
+    Files.write(outputFile, sourceCode.getBytes("UTF-8"))
+
+    List(outputFile.toAbsolutePath.toString)
+  }
+
+  private def findIzumiReflectClasspath(): String = {
+    val classpath = System.getProperty("java.class.path")
+    val classpathEntries = classpath.split(File.pathSeparator)
+
+    val izumiReflectJars = classpathEntries.filter(entry =>
+      entry.contains("izumi-reflect") && entry.endsWith(".jar")
+    )
+
+    if (izumiReflectJars.isEmpty) {
+      classpath
+    } else {
+      izumiReflectJars.mkString(File.pathSeparator)
+    }
+  }
+
+  private def clearGlobalCache(): Unit = {
+    try {
+      // Access the globalCache field directly from LightTypeTagImpl object
+      val lightTypeTagImplClass = Class.forName("izumi.reflect.macrortti.LightTypeTagImpl$")
+      val moduleField = lightTypeTagImplClass.getField("MODULE$")
+      val moduleInstance = moduleField.get(null)
+
+      // Get the globalCache field
+      val cacheField = lightTypeTagImplClass.getDeclaredField("globalCache")
+      cacheField.setAccessible(true)
+      val cache = cacheField.get(moduleInstance).asInstanceOf[java.util.concurrent.ConcurrentHashMap[Any, Any]]
+
+      val sizeBefore = cache.size()
+      cache.clear()
+      val sizeAfter = cache.size()
+
+      println(s"CACHE: Cleared $sizeBefore entries, now $sizeAfter entries")
+    } catch {
+      case e: Exception =>
+        // Also try clearing the Scala 3 cache in case we're in mixed mode
+        try {
+          val inspectClass = Class.forName("izumi.reflect.dottyreflection.Inspect$")
+          val moduleField = inspectClass.getField("MODULE$")
+          val moduleInstance = moduleField.get(null)
+          val cacheField = inspectClass.getDeclaredField("compilationCache")
+          cacheField.setAccessible(true)
+          val cache = cacheField.get(moduleInstance).asInstanceOf[java.util.concurrent.ConcurrentHashMap[Any, Any]]
+          val sizeBefore = cache.size()
+          cache.clear()
+          println(s"CACHE: Cleared Scala 3 cache: $sizeBefore entries")
+        } catch {
+          case e2: Exception =>
+            println(s"CACHE: Failed to clear caches: Scala 2: ${e.getMessage}, Scala 3: ${e2.getMessage}")
+        }
+    }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.exists()) {
+      if (file.isDirectory) {
+        Option(file.listFiles()).foreach(_.foreach(deleteRecursively))
+      }
+      file.delete()
+    }
+  }
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G", "-Xss8M"))
+class ColdTagCacheBenchmark extends BaseTagCacheBenchmark {
+  @Benchmark
+  def compile(blackhole: Blackhole): Unit = compileImpl(blackhole)
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G", "-Xss8M"))
+class WarmTagCacheBenchmark extends BaseTagCacheBenchmark {
+  @Benchmark
+  def compile(blackhole: Blackhole): Unit = compileImpl(blackhole)
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G", "-Xss8M"))
+class HotTagCacheBenchmark extends BaseTagCacheBenchmark {
+  @Benchmark
+  def compile(blackhole: Blackhole): Unit = compileImpl(blackhole)
+}

--- a/izumi-reflect/izumi-reflect-benchmark/src/main/scala-3/izumi/reflect/benchmark/TagCacheBenchmark.scala
+++ b/izumi-reflect/izumi-reflect-benchmark/src/main/scala-3/izumi/reflect/benchmark/TagCacheBenchmark.scala
@@ -1,0 +1,326 @@
+package izumi.reflect.benchmark
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.io.File
+import java.nio.file.{Files, Path}
+import java.util.concurrent.TimeUnit
+import scala.util.Try
+
+import dotty.tools.dotc.{Compiler, Driver}
+import dotty.tools.dotc.core.Contexts._
+
+import izumi.reflect.Tag
+
+@State(Scope.Benchmark)
+class BaseTagCacheBenchmark {
+
+  @Param(Array("5", "10", "20"))
+  var cacheMissPercentage: Int = _
+
+  @Param(Array("50"))
+  var totalTagOperations: Int = _
+
+  @Param(Array("true", "false"))
+  var cacheEnabled: String = _
+
+  private var tempDir: Path = _
+  private var sourceFiles: List[String] = _
+
+  @Setup(Level.Trial)
+  def setupTrial(): Unit = {
+    // Clear any existing cache state
+    System.gc()
+
+    if (cacheEnabled == "false") {
+      System.setProperty("izumi.reflect.rtti.cache.compile", "false")
+    } else {
+      System.clearProperty("izumi.reflect.rtti.cache.compile")
+    }
+
+    val benchmarkId = s"cache-${cacheEnabled}-miss-${cacheMissPercentage}-ops-${totalTagOperations}-${System.nanoTime()}"
+    tempDir = Files.createTempDirectory(s"izumi-reflect-benchmark-$benchmarkId")
+
+    sourceFiles = generateBenchmarkSources(tempDir)
+
+    val actualCacheSetting = Option(System.getProperty("izumi.reflect.rtti.cache.compile")).getOrElse("default(true)")
+    println(s"BENCHMARK: cache=$cacheEnabled, missRate=$cacheMissPercentage%, ops=$totalTagOperations, sysProp=$actualCacheSetting")
+  }
+
+  @Setup(Level.Iteration)
+  def setupIteration(): Unit = {
+    // Clear the global cache via reflection to ensure isolated iterations
+    clearGlobalCache()
+
+    // Keep same cache configuration for all iterations
+    if (cacheEnabled == "false") {
+      System.setProperty("izumi.reflect.rtti.cache.compile", "false")
+    } else {
+      System.clearProperty("izumi.reflect.rtti.cache.compile")
+    }
+
+    // DON'T generate new source files - reuse same files to test cache effectiveness!
+    // The cache should speed up compilation of the SAME types across multiple runs
+  }
+
+  @TearDown(Level.Trial)
+  def tearDownTrial(): Unit = {
+    Try {
+      deleteRecursively(tempDir.toFile)
+    }
+  }
+
+  def compileImpl(blackhole: Blackhole): Unit = {
+    if (cacheEnabled == "false") {
+      System.setProperty("izumi.reflect.rtti.cache.compile", "false")
+    } else {
+      System.clearProperty("izumi.reflect.rtti.cache.compile")
+    }
+
+    val iterationId = System.nanoTime()
+    val outputDir = tempDir.resolve(s"output-$iterationId")
+    if (Files.exists(outputDir)) {
+      deleteRecursively(outputDir.toFile)
+    }
+    Files.createDirectories(outputDir)
+
+    val dummyFile = outputDir.resolve("dummy.tmp")
+    Files.write(dummyFile, "warmup".getBytes())
+    Files.delete(dummyFile)
+
+    implicit val ctx = new ContextBase().initialCtx.fresh
+
+    ctx.setSetting(ctx.settings.usejavacp, true)
+    ctx.setSetting(ctx.settings.YdropComments, true)
+    ctx.setSetting(ctx.settings.silentWarnings, true)
+    ctx.setSetting(ctx.settings.language, List("Scala2"))
+    ctx.setSetting(ctx.settings.Vprofile, false)
+
+    val classpath = findIzumiReflectClasspath()
+    if (classpath.nonEmpty) {
+      ctx.setSetting(ctx.settings.classpath, classpath)
+    }
+
+    ctx.setSetting(ctx.settings.outputDir, dotty.tools.io.AbstractFile.getDirectory(outputDir.toAbsolutePath.toString))
+
+    val compiler = new dotty.tools.dotc.Compiler
+
+    val abstractFiles = sourceFiles.map { path =>
+      dotty.tools.io.AbstractFile.getFile(path)
+    }
+
+    Thread.sleep(1)
+
+    val run = compiler.newRun
+    run.compile(abstractFiles)
+    val reporter = ctx.reporter
+
+    if (reporter.hasErrors) {
+      val errors = reporter.allErrors.map(_.message).mkString("; ")
+      throw new RuntimeException(s"Compilation failed: cache=$cacheEnabled, miss=$cacheMissPercentage%, errors=$errors")
+    }
+
+    blackhole.consume(reporter)
+    blackhole.consume(outputDir.toString)
+    blackhole.consume(sourceFiles.length)
+    blackhole.consume(classpath)
+  }
+
+  private def generateBenchmarkSources(srcDir: Path, iterationId: Option[Long] = None): List[String] = {
+    val missCount = (totalTagOperations * cacheMissPercentage) / 100
+    val hitCount = totalTagOperations - missCount
+
+    // Generate realistic domain models that would use izumi-reflect
+    val domainClasses = """
+  // Realistic domain models like you'd find in a large codebase
+  trait EventStore[F[_], Event]
+  trait EventHandler[F[_], Event, Result]
+  trait Repository[F[_], Entity, Id]
+  trait Service[F[_], Request, Response]
+  trait Cache[F[_], K, V]
+  trait Metrics[F[_]]
+  trait Logger[F[_]]
+
+  case class UserId(value: String) extends AnyVal
+  case class OrderId(value: String) extends AnyVal
+  case class ProductId(value: String) extends AnyVal
+
+  sealed trait UserEvent
+  case class UserCreated(id: UserId, email: String, timestamp: Long) extends UserEvent
+  case class UserUpdated(id: UserId, changes: Map[String, Any], timestamp: Long) extends UserEvent
+  case class UserDeleted(id: UserId, timestamp: Long) extends UserEvent
+
+  case class User(id: UserId, email: String, profile: UserProfile)
+  case class UserProfile(firstName: String, lastName: String, preferences: Map[String, String])
+  case class Order(id: OrderId, userId: UserId, status: OrderStatus, items: List[OrderItem])
+  case class OrderItem(productId: ProductId, quantity: Int, price: BigDecimal)
+
+  sealed trait OrderStatus
+  case object Pending extends OrderStatus
+  case object Processing extends OrderStatus
+  case object Shipped extends OrderStatus"""
+
+    // Generate unique types for cache misses
+    val uniqueTypes = (0 until missCount).map { i =>
+      s"""  case class UserEvent$i(data: String) extends UserEvent
+  case class CreateRequest$i(email: String, profile: UserProfile)"""
+    }.mkString("\n")
+
+    // Generate cache miss tags - simple unique types
+    val cacheMissTagDefs = (0 until missCount).map { i =>
+      s"  val missTag$i = Tag[UserEvent$i]"
+    }.mkString("\n")
+
+    // Generate cache hit tags - simple repeated types
+    val commonTypes = List(
+      "User",
+      "Order",
+      "UserEvent",
+      "OrderId"
+    )
+
+    val cacheHitTagDefs = (0 until hitCount).map { i =>
+      val commonType = commonTypes(i % commonTypes.length)
+      s"  val hitTag$i = Tag[$commonType]"
+    }.mkString("\n")
+
+    // Generate cache-friendly tag patterns for enterprise codebases
+    val manyTagsUsage = s"""
+  object ServiceRegistry {
+    // Shared repository types (high cache reuse)
+    ${(0 until hitCount / 2).map(i => s"val userRepo$i = Tag[Repository[scala.concurrent.Future, User, UserId]]").mkString("\n    ")}
+
+    // Shared service types (high cache reuse)
+    ${(0 until hitCount / 2).map(i => s"val userService$i = Tag[Service[scala.concurrent.Future, User, Either[String, User]]]").mkString("\n    ")}
+
+    // Force tag evaluation
+    val allTags = List(
+      ${(0 until hitCount / 2).map(i => s"userRepo$i.tag").mkString(", ")},
+      ${(0 until hitCount / 2).map(i => s"userService$i.tag").mkString(", ")}
+    )
+  }"""
+
+    val packageSuffix = iterationId.map(id => s"_$id").getOrElse("")
+    val sourceCode = s"package izumi.reflect.benchmark.generated$packageSuffix" + "\n\n" +
+      "import izumi.reflect.Tag" + "\n\n" +
+      "object TagBenchmarkCode {" + "\n" +
+      domainClasses + "\n\n" +
+      uniqueTypes + "\n\n" +
+      cacheMissTagDefs + "\n\n" +
+      cacheHitTagDefs + "\n\n" +
+      manyTagsUsage + "\n\n" +
+      "  val allTags = Seq(" + "\n" +
+      (0 until missCount).map(i => s"    missTag$i").mkString(",\n") +
+      (if (missCount > 0 && hitCount > 0) ",\n" else "\n") +
+      (0 until hitCount).map(i => s"    hitTag$i").mkString(",\n") + "\n" +
+      "  )" + "\n\n" +
+      "  val tagData = allTags.map(_.tag.longNameWithPrefix)" + "\n" +
+      "  val tagUsage = tagData.zipWithIndex.map { case (name, idx) =>" + "\n" +
+      "    s\"${idx}_${name.hashCode}\"" + "\n" +
+      "  }.mkString(\",\")" + "\n\n" +
+      "  val tagCount = allTags.length" + "\n" +
+      "  val tagSample = if (allTags.nonEmpty) allTags.head.tag.longNameWithPrefix else \"none\"" + "\n" +
+      "  \n  // Force evaluation of the ServiceRegistry to trigger tag computation" + "\n" +
+      "  val registryData = ServiceRegistry.allTags.map(_.longNameWithPrefix)" + "\n" +
+      "}"
+
+    val fileName = iterationId.map(id => s"TagBenchmarkCode_$id.scala").getOrElse("TagBenchmarkCode.scala")
+    val outputFile = srcDir.resolve(fileName)
+    Files.write(outputFile, sourceCode.getBytes("UTF-8"))
+
+    List(outputFile.toAbsolutePath.toString)
+  }
+
+  private def findIzumiReflectClasspath(): String = {
+    val classpath = System.getProperty("java.class.path")
+    val classpathEntries = classpath.split(File.pathSeparator)
+
+    val izumiReflectJars = classpathEntries.filter(entry =>
+      entry.contains("izumi-reflect") && entry.endsWith(".jar")
+    )
+
+    if (izumiReflectJars.isEmpty) {
+      classpath
+    } else {
+      izumiReflectJars.mkString(File.pathSeparator)
+    }
+  }
+
+  private def clearGlobalCache(): Unit = {
+    try {
+      // Clear the Scala 3 compilation cache first
+      val inspectClass = Class.forName("izumi.reflect.dottyreflection.Inspect$")
+      val moduleField = inspectClass.getField("MODULE$")
+      val moduleInstance = moduleField.get(null)
+      val cacheField = inspectClass.getDeclaredField("compilationCache")
+      cacheField.setAccessible(true)
+      val cache = cacheField.get(moduleInstance).asInstanceOf[java.util.concurrent.ConcurrentHashMap[Any, Any]]
+
+      val sizeBefore = cache.size()
+      cache.clear()
+      val sizeAfter = cache.size()
+
+      println(s"CACHE: Cleared Scala 3 cache: $sizeBefore entries, now $sizeAfter entries")
+    } catch {
+      case e: Exception =>
+        // Also try clearing the Scala 2 cache in case we're in mixed mode
+        try {
+          val lightTypeTagImplClass = Class.forName("izumi.reflect.macrortti.LightTypeTagImpl$")
+          val moduleField = lightTypeTagImplClass.getField("MODULE$")
+          val moduleInstance = moduleField.get(null)
+          val cacheField = lightTypeTagImplClass.getDeclaredField("globalCache")
+          cacheField.setAccessible(true)
+          val cache = cacheField.get(moduleInstance).asInstanceOf[java.util.concurrent.ConcurrentHashMap[Any, Any]]
+          val sizeBefore = cache.size()
+          cache.clear()
+          println(s"CACHE: Cleared Scala 2 cache: $sizeBefore entries")
+        } catch {
+          case e2: Exception =>
+            println(s"CACHE: Failed to clear caches: Scala 3: ${e.getMessage}, Scala 2: ${e2.getMessage}")
+        }
+    }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.exists()) {
+      if (file.isDirectory) {
+        Option(file.listFiles()).foreach(_.foreach(deleteRecursively))
+      }
+      file.delete()
+    }
+  }
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 0)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-XX:CICompilerCount=2", "-Xms2G", "-Xmx2G", "-Xss2M"))
+class ColdTagCacheBenchmark extends BaseTagCacheBenchmark {
+  @Benchmark
+  def compile(blackhole: Blackhole): Unit = compileImpl(blackhole)
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G", "-Xss8M"))
+class WarmTagCacheBenchmark extends BaseTagCacheBenchmark {
+  @Benchmark
+  def compile(blackhole: Blackhole): Unit = compileImpl(blackhole)
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms4G", "-Xmx4G", "-Xss8M"))
+class HotTagCacheBenchmark extends BaseTagCacheBenchmark {
+  @Benchmark
+  def compile(blackhole: Blackhole): Unit = compileImpl(blackhole)
+}

--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -35,7 +35,7 @@ import scala.language.reflectiveCalls
 import scala.reflect.api.Universe
 
 object LightTypeTagImpl {
-  private lazy val globalCache = new java.util.WeakHashMap[Any, AbstractReference]
+  private lazy val globalCache = new java.util.concurrent.ConcurrentHashMap[Any, AbstractReference]
 
   /** caching is enabled by default for runtime light type tag creation */
   private[this] lazy val runtimeCacheEnabled: Boolean = {
@@ -415,11 +415,11 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
 
   private[this] def makeRef(tpe: Type): AbstractReference = {
     if (withCache) {
-      globalCache.synchronized(globalCache.get(tpe)) match {
+      globalCache.get(tpe) match {
         case null =>
           val ref = makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)
-          globalCache.synchronized(globalCache.put(tpe, ref))
-          ref
+          globalCache.putIfAbsent(tpe, ref)
+          globalCache.get(tpe) // Return the cached value in case another thread computed it first
         case ref =>
           ref
       }

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspect.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspect.scala
@@ -3,21 +3,55 @@ package izumi.reflect.dottyreflection
 import izumi.reflect.macrortti.LightTypeTag
 import izumi.reflect.macrortti.LightTypeTag.ParsedLightTypeTag.SubtypeDBs
 import izumi.reflect.thirdparty.internal.boopickle.PickleImpl
+import izumi.reflect.DebugProperties
+import izumi.reflect.internal.fundamentals.platform.strings.IzString._
 
 import scala.quoted.{Expr, Quotes, Type}
+import java.util.concurrent.ConcurrentHashMap
 
 object Inspect {
+  private val compilationCache = new ConcurrentHashMap[Any, LightTypeTag]()
+  
+  /** caching is enabled by default for compile-time light type tag creation */
+  private lazy val compileCacheEnabled: Boolean = {
+    System
+      .getProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`).asBoolean()
+      .getOrElse(true)
+  }
+  
   inline def inspect[T <: AnyKind]: LightTypeTag = ${ inspectAny[T] }
 
   inline def inspectStrong[T <: AnyKind]: LightTypeTag = ${ inspectStrong[T] }
 
   def inspectAny[T <: AnyKind: Type](using qctx: Quotes): Expr[LightTypeTag] = {
-    val ltt = {
-      val ref = TypeInspections.apply[T]
-      val fullDb = TypeInspections.fullDb[T]
-      val nameDb = TypeInspections.unappliedDb[T]
-      LightTypeTag(ref, fullDb, nameDb)
+    import qctx.reflect.*
+    
+    if (compileCacheEnabled) {
+      val tpe = TypeRepr.of[T]
+      
+      val cached = compilationCache.get(tpe) match {
+        case null =>
+          val ref = TypeInspections.apply[T]
+          val fullDb = TypeInspections.fullDb[T]
+          val nameDb = TypeInspections.unappliedDb[T]
+          val ltt = LightTypeTag(ref, fullDb, nameDb)
+          compilationCache.putIfAbsent(tpe, ltt)
+          compilationCache.get(tpe) // Return the cached value in case another thread computed it first
+        case cached =>
+          cached
+      }
+      
+      makeParsedLightTypeTagImpl(cached)
+    } else {
+      computeLightTypeTag[T]
     }
+  }
+  
+  private def computeLightTypeTag[T <: AnyKind: Type](using qctx: Quotes): Expr[LightTypeTag] = {
+    val ref = TypeInspections.apply[T]
+    val fullDb = TypeInspections.fullDb[T]
+    val nameDb = TypeInspections.unappliedDb[T]
+    val ltt = LightTypeTag(ref, fullDb, nameDb)
     makeParsedLightTypeTagImpl(ltt)
   }
 

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -8,11 +8,13 @@ object Izumi {
     val kind_projector = Version.VExpr("V.kind_projector")
     val scalatest = Version.VExpr("V.scalatest")
     val sbtgen = Version.VExpr("V.sbtgen")
+    val jmh = Version.VExpr("V.jmh")
   }
 
   object PV {
     val sbt_scoverage = Version.VExpr("PV.sbt_scoverage")
     val sbt_pgp = Version.VExpr("PV.sbt_pgp")
+    val sbt_jmh = Version.VExpr("PV.sbt_jmh")
 
     val scala_js_version = Version.VExpr("PV.scala_js_version")
     val scala_native_version = Version.VExpr("PV.scala_native_version")
@@ -32,6 +34,7 @@ object Izumi {
   var targetScala = Seq(scala300, scala213, scala212, scala211)
 
   def entrypoint(args: Seq[String]) = {
+    val benchmarkEnabled = args.contains("--benchmark")
     val newArgs = args diff Seq(
       args
         .collectFirst {
@@ -43,15 +46,17 @@ object Izumi {
           case (s, target) =>
             targetScala = target :: targetScala.filterNot(_ == target).toList
             s
-        }.orNull
-    )
+        }.orNull,
+      if (benchmarkEnabled) "--benchmark" else null
+    ).filter(_ != null)
     if (args.contains("--help")) {
       println(
-        "launch with `./sbtgen.sc 3` to use Scala 3 in IDEA, launch with `./sbtgen.sc 2` to use Scala 2"
+        "launch with `./sbtgen.sc 3` to use Scala 3 in IDEA, launch with `./sbtgen.sc 2` to use Scala 2, launch with `--benchmark` to include benchmarks"
       )
     }
     println(s"Scala targets: $targetScala")
-    Entrypoint.main(izumi_reflect, settings, Seq("-o", ".") ++ newArgs)
+    println(s"Benchmark enabled: $benchmarkEnabled")
+    Entrypoint.main(izumi_reflect(benchmarkEnabled), settings, Seq("-o", ".") ++ newArgs)
   }
 
   val settings = GlobalSettings(
@@ -66,10 +71,16 @@ object Izumi {
     final val scalatest = Library("org.scalatest", "scalatest", V.scalatest, LibraryType.Auto)
 
     final val scala_reflect = Library("org.scala-lang", "scala-reflect", Version.VExpr("scalaVersion.value"), LibraryType.Invariant)
+    final val scala_compiler = Library("org.scala-lang", "scala-compiler", Version.VExpr("scalaVersion.value"), LibraryType.Invariant)
     final val scala3_compiler = Library("org.scala-lang", "scala3-compiler", Version.VExpr("scalaVersion.value"), LibraryType.AutoJvm)
+    final val scala3_compiler_runtime = Library("org.scala-lang", "scala3-compiler", Version.VExpr("scalaVersion.value"), LibraryType.AutoJvm)
 
     final val projector = Library("org.typelevel", "kind-projector", V.kind_projector, LibraryType.Invariant)
       .more(LibSetting.Raw("cross CrossVersion.full"))
+
+    // JMH dependencies for benchmarking - use Invariant to avoid Scala cross-compilation
+    final val jmh_core = Library("org.openjdk.jmh", "jmh-core", Version.VExpr("V.jmh"), LibraryType.Invariant)
+    final val jmh_generator = Library("org.openjdk.jmh", "jmh-generator-annprocess", Version.VExpr("V.jmh"), LibraryType.Invariant)
   }
 
   import Deps._
@@ -240,6 +251,21 @@ object Izumi {
         // https://github.com/scala-steward-org/scala-steward/issues/696#issuecomment-545800968
         "libraryDependencies" += s""""io.7mind.izumi.sbt" % "sbtgen_2.13" % "${Version.SbtGen.value}" % Provided""".raw
       )
+      
+      def benchmarkCommandAliases = Seq(
+        SettingDef.RawSettingDef(
+          """addCommandAlias("benchmarkHot", "izumi-reflect-benchmark/jmh:run HotTagCacheBenchmark -foe true")""",
+          FullSettingScope(SettingScope.Raw("Global"), Platform.All)
+        ),
+        SettingDef.RawSettingDef(
+          """addCommandAlias("benchmarkWarm", "izumi-reflect-benchmark/jmh:run WarmTagCacheBenchmark -foe true")""",
+          FullSettingScope(SettingScope.Raw("Global"), Platform.All)
+        ),
+        SettingDef.RawSettingDef(
+          """addCommandAlias("benchmarkCold", "izumi-reflect-benchmark/jmh:run ColdTagCacheBenchmark -foe true")""",
+          FullSettingScope(SettingScope.Raw("Global"), Platform.All)
+        )
+      )
 
       final val sharedSettings =
         Defaults.CrossScalaPlusSources ++
@@ -310,13 +336,13 @@ object Izumi {
 
       final val izumi_reflect = ArtifactId("izumi-reflect")
       final val thirdpartyBoopickleShaded = ArtifactId("izumi-reflect-thirdparty-boopickle-shaded")
+      final val benchmark = ArtifactId("izumi-reflect-benchmark")
     }
 
   }
 
-  final lazy val izumi_reflect_aggregate = Aggregate(
-    name = Projects.izumi_reflect_aggregate.id,
-    artifacts = Seq(
+  def izumi_reflect_aggregate(benchmarkEnabled: Boolean) = {
+    val baseArtifacts = Seq(
       Artifact(
         name = Projects.izumi_reflect_aggregate.thirdpartyBoopickleShaded,
         libs = Seq.empty,
@@ -335,42 +361,94 @@ object Izumi {
           Projects.izumi_reflect_aggregate.thirdpartyBoopickleShaded
         )
       )
-    ),
-    pathPrefix = Projects.izumi_reflect_aggregate.basePath,
-    groups = Groups.izumi_reflect,
-    defaultPlatforms = Targets.crossNative,
-    enableProjectSharedAggSettings = false,
-    settings = Seq(
-      "crossScalaVersions" := "Nil".raw
     )
-  )
+    
+    val benchmarkPlatforms = Seq(
+      PlatformEnv(
+        platform = Platform.Jvm,
+        language = Seq(scala300, scala213)
+      )
+    )
 
-  final lazy val izumi_reflect: Project = Project(
-    name = Projects.root.id,
-    aggregates = Seq(
-      izumi_reflect_aggregate
-    ),
-    topLevelSettings = Projects.root.topLevelSettings,
-    sharedSettings = Projects.root.sharedSettings,
-    sharedAggSettings = Projects.root.sharedAggSettings,
-    rootSettings = Projects.root.rootSettings,
-    imports = Seq(
-      Import("com.typesafe.tools.mima.core._")
-    ),
-    globalLibs = Seq(
-      ScopedLibrary(projector, FullDependencyScope(Scope.Compile, Platform.All).scalaVersion(ScalaVersionScope.AllScala2), compilerPlugin = true),
-      scala_reflect in Scope.Provided.all.scalaVersion(ScalaVersionScope.AllScala2),
-      scala3_compiler in Scope.Provided.all.scalaVersion(ScalaVersionScope.AllScala3),
-      scalatest in Scope.Test.all
-    ),
-    rootPlugins = Projects.root.plugins,
-    globalPlugins = Plugins(),
-    pluginConflictRules = Map.empty,
-    appendPlugins = Defaults.SbtGenPlugins ++ Seq(
+    val benchmarkArtifact = Artifact(
+      name = Projects.izumi_reflect_aggregate.benchmark,
+      libs = Seq(
+        jmh_core, 
+        jmh_generator, 
+        scala_compiler in Scope.Compile.all.scalaVersion(ScalaVersionScope.AllScala2),
+        scala3_compiler in Scope.Compile.all.scalaVersion(ScalaVersionScope.AllScala3)
+      ),
+      depends = Seq(
+        Projects.izumi_reflect_aggregate.izumi_reflect
+      ),
+      platforms = benchmarkPlatforms,
+      plugins = Plugins(
+        enabled = Seq(Plugin("JmhPlugin")),
+        disabled = Seq.empty
+      ),
+      settings = Seq(
+        "crossScalaVersions" := Seq(scala300.value, scala213.value),
+        "scalaVersion" := scala300.value
+      )
+    )
+    
+    val allArtifacts = if (benchmarkEnabled) baseArtifacts :+ benchmarkArtifact else baseArtifacts
+
+    Aggregate(
+      name = Projects.izumi_reflect_aggregate.id,
+      artifacts = allArtifacts,
+      pathPrefix = Projects.izumi_reflect_aggregate.basePath,
+      groups = Groups.izumi_reflect,
+      defaultPlatforms = Targets.crossNative,
+      enableProjectSharedAggSettings = false,
+      settings = Seq(
+        "crossScalaVersions" := "Nil".raw
+      )
+    )
+  }
+
+  def izumi_reflect(benchmarkEnabled: Boolean): Project = {
+    val basePlugins = Defaults.SbtGenPlugins ++ Seq(
       SbtPlugin("com.github.sbt", "sbt-pgp", PV.sbt_pgp),
       SbtPlugin("org.scoverage", "sbt-scoverage", PV.sbt_scoverage),
       SbtPlugin("com.typesafe", "sbt-mima-plugin", PV.sbt_mima_version),
       SbtPlugin("dev.zio", "zio-sbt-website", PV.zio_sbt_website)
     )
-  )
+    
+    val allPlugins = if (benchmarkEnabled) {
+      basePlugins :+ SbtPlugin("pl.project13.scala", "sbt-jmh", PV.sbt_jmh)
+    } else {
+      basePlugins
+    }
+    
+    val allRootSettings = if (benchmarkEnabled) {
+      Projects.root.rootSettings ++ Projects.root.benchmarkCommandAliases
+    } else {
+      Projects.root.rootSettings
+    }
+    
+    Project(
+      name = Projects.root.id,
+      aggregates = Seq(
+        izumi_reflect_aggregate(benchmarkEnabled)
+      ),
+      topLevelSettings = Projects.root.topLevelSettings,
+      sharedSettings = Projects.root.sharedSettings,
+      sharedAggSettings = Projects.root.sharedAggSettings,
+      rootSettings = allRootSettings,
+      imports = Seq(
+        Import("com.typesafe.tools.mima.core._")
+      ),
+      globalLibs = Seq(
+        ScopedLibrary(projector, FullDependencyScope(Scope.Compile, Platform.All).scalaVersion(ScalaVersionScope.AllScala2), compilerPlugin = true),
+        scala_reflect in Scope.Provided.all.scalaVersion(ScalaVersionScope.AllScala2),
+        scala3_compiler in Scope.Provided.all.scalaVersion(ScalaVersionScope.AllScala3),
+        scalatest in Scope.Test.all
+      ),
+      rootPlugins = Projects.root.plugins,
+      globalPlugins = Plugins(),
+      pluginConflictRules = Map.empty,
+      appendPlugins = allPlugins
+    )
+  }
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,4 +19,5 @@
 object V {
   val kind_projector = "0.13.3"
   val scalatest = "3.2.19"
+  val jmh = "1.37"
 }

--- a/project/project/PluginVersions.scala
+++ b/project/project/PluginVersions.scala
@@ -20,6 +20,8 @@ object PV {
   val sbt_scoverage = "2.3.1"
   
   val sbt_pgp = "2.3.1"
+  
+  val sbt_jmh = "0.4.7"
 
   val sbt_mima_version = "1.1.0"
 


### PR DESCRIPTION
This PR changes caching to use `ConcurrentHashMap` for both Scala 2 and Scala 3 implementations.

I've referenced the [compiler benchmark](https://github.com/scala/compiler-benchmark) workflow from Scala this time for the PR and added JMH via a `--benchmark` flag for builds.

It also includes easy to use commands for testing:

```bash
sbt benchmarkCold
sbt benchmarkWarm
sbt benchmarkHot
```

Let me run tests with `WeakHashMap` first and also make sure the benchmark itself works properly before merging.

Feel free to review and give feedback on the benchmarking patterns done though.

I need to fix up how cache isolation and clearing is done, and, more then likely, you need to do Scala specific builds instead of the mixed implementation I currently have.