### PR TITLE
scalaStyledName: render complex lambdas using long-form instead of placeholders

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
@@ -236,18 +236,62 @@ object LTTRenderables {
   }
 
   object ScalaStyledLambdas extends Long {
-
-    override def prefixSplitter: String = "."
-
     override implicit lazy val r_LambdaParameterName: Renderable[SymName.LambdaParamName] = new Renderable[SymName.LambdaParamName] {
       override def render(value: SymName.LambdaParamName): String = "_"
     }
 
     override implicit lazy val r_Lambda: Renderable[Lambda] = new Renderable[Lambda] {
       override def render(value: Lambda): String = {
-        s"${value.output.render()}"
+        val isSimpleShape = value match {
+          case Lambda(input, FullReference(_, tparams, _)) =>
+            val (unusedRemaining, suspicious) = tparams.foldLeft((input, List.empty[AbstractReference])) {
+              // params must be applied in definition order
+              case ((all @ unusedArg :: tl, suspicious), TypeParam(p: AppliedNamedReference, variance)) =>
+                if (p.symName == unusedArg) {
+                  p match {
+                    case _: NameReference =>
+                      (tl, suspicious)
+                    case FullReference(symName, parameters, prefix) =>
+                      (tl, parameters.map(_.ref) ++ suspicious)
+                  }
+                } else {
+                  (all, p :: suspicious)
+                }
+              case ((all, suspicious), TypeParam(other, _)) => (all, other :: suspicious)
+            }
+            val innerUses = suspicious.iterator.flatMap(RuntimeAPI.unpack).map(_.symName).toSet
+            unusedRemaining.isEmpty && input.toSet.intersect(innerUses).isEmpty
+          case _ =>
+            false
+        }
+        if (isSimpleShape) {
+          s"${value.output.render()}"
+        } else {
+          ScalaStyledLambdasLong.r_Lambda.render(value)
+        }
       }
     }
+  }
+
+  object ScalaStyledLambdasLong extends ScalaStyledLambdasShared {
+    override implicit lazy val r_LambdaParameterName: Renderable[SymName.LambdaParamName] = new Renderable[SymName.LambdaParamName] {
+      override def render(value: SymName.LambdaParamName): String = {
+        val char = ('A' + (value.index % 25)).toChar.toString
+        val numChars = 1 + value.index / 25
+        val suffix = if (value.depth > 0) s"${value.depth}" else ""
+        s"${char.repeat(numChars)}$suffix"
+      }
+    }
+
+    override implicit lazy val r_Lambda: Renderable[Lambda] = new Renderable[Lambda] {
+      override def render(value: Lambda): String = {
+        s"[${value.input.map(_.render()).mkString(",")}] ➾ ${value.output.render()}"
+      }
+    }
+  }
+
+  private[LTTRenderables] trait ScalaStyledLambdasShared extends Long {
+    override def prefixSplitter: String = "."
 
     override implicit lazy val r_Variance: Renderable[Variance] = new Renderable[Variance] {
       override def render(value: Variance): String = value match {

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
@@ -279,7 +279,7 @@ object LTTRenderables {
         val char = ('A' + (value.index % 25)).toChar.toString
         val numChars = 1 + value.index / 25
         val suffix = if (value.depth > 0) s"${value.depth}" else ""
-        s"${char.repeat(numChars)}$suffix"
+        s"${char * numChars}$suffix"
       }
     }
 

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
@@ -25,6 +25,7 @@ class LTTRenderablesTest extends TagAssertions {
       type SwapOptionT[A, B[_]] = OptionT[B, A]
       type UseInner[A] = OptionT[Either[A, *], A]
       type UseInner2[A, B] = OptionT[Either[A, *], B]
+      type Reuse[A] = Either[A, A]
 
       val identity = `LTT[_]`[ID.Identity].scalaStyledName
       val const = `LTT[_,_]`[Const].scalaStyledName
@@ -32,6 +33,7 @@ class LTTRenderablesTest extends TagAssertions {
       val swapOptionT = `LTT[_]`[SwapOptionT[*, ID.Identity]].scalaStyledName
       val useInner = `LTT[_]`[UseInner].scalaStyledName
       val useInner2 = `LTT[_,_]`[UseInner2].scalaStyledName
+      val reuse = `LTT[_]`[Reuse].scalaStyledName
 
       assert(identity == "[A] ➾ A")
       assert(const == "[A,B] ➾ B")
@@ -39,6 +41,7 @@ class LTTRenderablesTest extends TagAssertions {
       assert(swapOptionT == "izumi.reflect.test.OptionT[=[A1] ➾ A1,=_]")
       assert(useInner == "[A] ➾ izumi.reflect.test.OptionT[[A1] ➾ scala.util.Either[+A,+A1],A]")
       assert(useInner2 == "[A,B] ➾ izumi.reflect.test.OptionT[[A1] ➾ scala.util.Either[+A,+A1],B]")
+      assert(reuse == "[A] ➾ scala.util.Either[+A,+A]")
     }
   }
 

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
@@ -1,0 +1,45 @@
+package izumi.reflect.test
+
+import izumi.reflect.macrortti.*
+
+class LTTRenderablesTest extends TagAssertions {
+
+  "LTT renderables" should {
+    "render simple lambdas using placeholders when using scalaStyledName" in {
+      val list = `LTT[_]`[List].scalaStyledName
+      val either = `LTT[_,_]`[Either].scalaStyledName
+      val either2 = `LTT[_]`[Either[Int, *]].scalaStyledName
+      val either3 = `LTT[_]`[Either[*, Int]].scalaStyledName
+      val optionT = `LTT[_]`[OptionT[List, *]].scalaStyledName
+
+      assert(list == "scala.collection.immutable.List[+_]")
+      assert(either == "scala.util.Either[+_,+_]")
+      assert(either2 == "scala.util.Either[+scala.Int,+_]")
+      assert(either3 == "scala.util.Either[+_,+scala.Int]")
+      assert(optionT == "izumi.reflect.test.OptionT[=scala.collection.immutable.List[+_],=_]")
+    }
+
+    "render complex lambdas using long form when using scalaStyledName" in {
+      type Const[+A, +B] = B
+      type SwapEither[+A, +B] = Either[B, A]
+      type SwapOptionT[A, B[_]] = OptionT[B, A]
+      type UseInner[A] = OptionT[Either[A, *], A]
+      type UseInner2[A, B] = OptionT[Either[A, *], B]
+
+      val identity = `LTT[_]`[ID.Identity].scalaStyledName
+      val const = `LTT[_,_]`[Const].scalaStyledName
+      val swapEither = `LTT[_,_]`[SwapEither].scalaStyledName
+      val swapOptionT = `LTT[_]`[SwapOptionT[*, ID.Identity]].scalaStyledName
+      val useInner = `LTT[_]`[UseInner].scalaStyledName
+      val useInner2 = `LTT[_,_]`[UseInner2].scalaStyledName
+
+      assert(identity == "[A] ➾ A")
+      assert(const == "[A,B] ➾ B")
+      assert(swapEither == "[A,B] ➾ scala.util.Either[+B,+A]")
+      assert(swapOptionT == "izumi.reflect.test.OptionT[=[A1] ➾ A1,=_]")
+      assert(useInner == "[A] ➾ izumi.reflect.test.OptionT[[A1] ➾ scala.util.Either[+A,+A1],A]")
+      assert(useInner2 == "[A,B] ➾ izumi.reflect.test.OptionT[[A1] ➾ scala.util.Either[+A,+A1],B]")
+    }
+  }
+
+}

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
@@ -38,9 +38,10 @@ class LTTRenderablesTest extends TagAssertions {
       assert(identity == "[A] ➾ A")
       assert(const == "[A,B] ➾ B")
       assert(swapEither == "[A,B] ➾ scala.util.Either[+B,+A]")
-      assert(swapOptionT == "izumi.reflect.test.OptionT[=[A1] ➾ A1,=_]")
-      assert(useInner == "[A] ➾ izumi.reflect.test.OptionT[[A1] ➾ scala.util.Either[+A,+A1],A]")
-      assert(useInner2 == "[A,B] ➾ izumi.reflect.test.OptionT[[A1] ➾ scala.util.Either[+A,+A1],B]")
+      val expectedDepth = if (IsScala3) 1 else 2
+      assert(swapOptionT == s"izumi.reflect.test.OptionT[=[A$expectedDepth] ➾ A$expectedDepth,=_]")
+      assert(useInner == s"[A] ➾ izumi.reflect.test.OptionT[[A$expectedDepth] ➾ scala.util.Either[+A,+A$expectedDepth],A]")
+      assert(useInner2 == s"[A,B] ➾ izumi.reflect.test.OptionT[[A$expectedDepth] ➾ scala.util.Either[+A,+A$expectedDepth],B]")
       assert(reuse == "[A] ➾ scala.util.Either[+A,+A]")
     }
   }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
@@ -1,6 +1,6 @@
 package izumi.reflect.test
 
-import izumi.reflect.macrortti.*
+import izumi.reflect.macrortti._
 
 class LTTRenderablesTest extends TagAssertions {
 

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TagCombineTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TagCombineTest.scala
@@ -3,7 +3,7 @@ package izumi.reflect.test
 import izumi.reflect.macrortti.LightTypeTag
 import izumi.reflect.{Tag, TagK, TagK3}
 
-object TagMacroTest {
+object TagCombineTest {
   trait P
   trait C extends P
   trait HuIO[-R, +E, +I]
@@ -18,8 +18,8 @@ object TagMacroTest {
 
 }
 
-class TagMacroTest extends TagAssertions {
-  import TagMacroTest._
+class TagCombineTest extends TagAssertions {
+  import TagCombineTest._
   "Tag macro" should {
     "reconstruct lambda tags" in {
       val expected = Tag[HuIO[Any, Int, C]].tag


### PR DESCRIPTION
/claim #384