### PR TITLE
Rename LightTypeTag.scalaStyledName -> scalaStyledRepr, fix misnomer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -641,6 +641,7 @@ lazy val `izumi-reflect-root` = (project in file("."))
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef#AppliedNamedReference.symName"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef#AppliedNamedReference.prefix"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef.scalaStyledName"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef.scalaStyledRepr"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.AnyTag.=:="),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.AnyTag.<:<"),
       ProblemFilters.exclude[Problem]("izumi.reflect.TagMacro.*"),

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTSyntax.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTSyntax.scala
@@ -87,21 +87,21 @@ private[macrortti] trait LTTSyntax {
     (this: LightTypeTagRef).render()
   }
 
+  protected[this] final def scalaStyledReprImpl: String = {
+    import izumi.reflect.macrortti.LTTRenderables.ScalaStyledLambdas._
+    (this: LightTypeTagRef).render()
+  }
+
   protected[this] final def shortNameImpl: String = {
     getName(r => LTTRenderables.Short.r_SymName(r.symName, hasPrefix = false))
   }
 
   protected[this] final def longNameWithPrefixImpl: String = {
-    getName(r => LTTRenderables.LongPrefixDot.r_NameRefRenderer.render(NameReference(r.symName, Boundaries.Empty, r.prefix)))
+    getName(r => LTTRenderables.LongPrefixDot.r_NameRefRenderer.render(r.asName.copy(boundaries = Boundaries.Empty)))
   }
 
   protected[this] final def longNameInternalSymbolImpl: String = {
     getName(r => LTTRenderables.Long.r_SymName(r.symName, hasPrefix = false))
-  }
-
-  protected[this] final def scalaStyledNameImpl: String = {
-    import izumi.reflect.macrortti.LTTRenderables.ScalaStyledLambdas._
-    (this: LightTypeTagRef).render()
   }
 
   @deprecated(

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -241,25 +241,39 @@ abstract class LightTypeTag private[reflect] (
     ref.repr
   }
 
-  /** Short class or type-constructor name of this type, without package or prefix names */
-  def shortName: String = {
-    ref.shortName
-  }
-
-  /** Class or type-constructor name of this type, with package and prefix names */
-  def longNameWithPrefix: String = {
-    ref.longNameWithPrefix
-  }
-
-  /** Internal symbol name of type-constructor of this type, with package and containing definition names */
-  def longNameInternalSymbol: String = {
-    ref.longNameInternalSymbol
-  }
-
   /**
     * Fully-qualified rendering of a type, including packages and prefix types.
     * Traditional Scala notation for lambdas, e.g. scala.util.Either[+scala.Int,+_]
     */
+  def scalaStyledRepr: String = {
+    ref.scalaStyledRepr
+  }
+
+  /** Short class or type-constructor name of this type, without package or prefix names
+    *
+    * @note This will produce only a type constructor name, for full rendering of the type use [[toString]], [[repr]] or [[scalaStyledRepr]]
+    */
+  def shortName: String = {
+    ref.shortName
+  }
+
+  /** Class or type-constructor name of this type, with package and prefix names
+    *
+    * @note This will produce only a type constructor name, for full rendering of the type use [[toString]], [[repr]] or [[scalaStyledRepr]]
+    */
+  def longNameWithPrefix: String = {
+    ref.longNameWithPrefix
+  }
+
+  /** Internal symbol name of type-constructor of this type, with package and containing definition names
+    *
+    * @note This will produce only a type constructor name, for full rendering of the type use [[toString]], [[repr]] or [[scalaStyledRepr]]
+    */
+  def longNameInternalSymbol: String = {
+    ref.longNameInternalSymbol
+  }
+
+  @deprecated("Renamed to scalaStyledRepr", "3.0.8")
   def scalaStyledName: String = {
     ref.scalaStyledName
   }
@@ -354,20 +368,22 @@ object LightTypeTag {
   }
 
   def wildcardType(lowTag: LightTypeTag, highTag: LightTypeTag): LightTypeTag = {
-    val ref = LightTypeTagRef.WildcardReference(Boundaries.Defined(
-      lowTag.ref match { case r: AbstractReference => r },
-      highTag.ref match { case r: AbstractReference => r }
-    ))
+    val ref = LightTypeTagRef.WildcardReference(
+      Boundaries.Defined(
+        lowTag.ref match { case r: AbstractReference => r },
+        highTag.ref match { case r: AbstractReference => r }
+      )
+    )
 
     def mergedBasesDB: Map[AbstractReference, Set[AbstractReference]] =
       LightTypeTag.mergeIDBs(highTag.basesdb, lowTag.basesdb)
 
     def mergedInheritanceDb: Map[NameReference, Set[NameReference]] =
       LightTypeTag.mergeIDBs(highTag.idb, lowTag.idb)
-      
+
     LightTypeTag(ref, mergedBasesDB, mergedInheritanceDb)
   }
-  
+
   def parse(serialized: Serialized): LightTypeTag = {
     parse[LightTypeTag](serialized.hash, serialized.ref, serialized.databases, serialized.version)
   }

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagRef.scala
@@ -37,7 +37,9 @@ sealed trait LightTypeTagRef extends LTTSyntax with Serializable {
     * Use [[toString]] for a rendering that omits package names
     */
   final def repr: String = this.reprImpl
-  final def scalaStyledName: String = this.scalaStyledNameImpl
+  final def scalaStyledRepr: String = this.scalaStyledReprImpl
+  @deprecated("Renamed to scalaStyledRepr", "3.0.8")
+  final def scalaStyledName: String = this.scalaStyledReprImpl
   final def shortName: String = this.shortNameImpl
   final def longNameWithPrefix: String = this.longNameWithPrefixImpl
   final def longNameInternalSymbol: String = this.longNameInternalSymbolImpl
@@ -222,7 +224,7 @@ object LightTypeTagRef extends LTTOrdering {
   ) extends AppliedNamedReference {
     override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 
-    override def asName: NameReference = NameReference(symName, prefix = prefix)
+    override def asName: NameReference = NameReference(symName, boundaries = Boundaries.Empty, prefix = prefix)
 
     @deprecated("bincompat only", "20.02.2023")
     private[LightTypeTagRef] def ref: String = SymName.forceName(symName)

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -169,6 +169,7 @@ object Izumi {
           """ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef#AppliedNamedReference.symName")""".raw,
           """ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef#AppliedNamedReference.prefix")""".raw,
           """ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef.scalaStyledName")""".raw,
+          """ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.macrortti.LightTypeTagRef.scalaStyledRepr")""".raw,
           """ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.AnyTag.=:=")""".raw,
           """ProblemFilters.exclude[ReversedMissingMethodProblem]("izumi.reflect.AnyTag.<:<")""".raw,
           // compile-time only


### PR DESCRIPTION
Deprecate old name