### PR TITLE
Fix 3.0.7 regression, render types with `.` prefix splitters again in `scalaStyledRepr`

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LTTRenderables.scala
@@ -235,7 +235,7 @@ object LTTRenderables {
     override def prefixSplitter: String = "."
   }
 
-  object ScalaStyledLambdas extends Long {
+  object ScalaStyledLambdas extends ScalaStyledLambdasShared {
     override implicit lazy val r_LambdaParameterName: Renderable[SymName.LambdaParamName] = new Renderable[SymName.LambdaParamName] {
       override def render(value: SymName.LambdaParamName): String = "_"
     }

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/LTTRenderablesTest.scala
@@ -4,6 +4,12 @@ import izumi.reflect.macrortti._
 
 class LTTRenderablesTest extends TagAssertions {
 
+  object X {
+    object Y {
+      class C
+    }
+  }
+
   "LTT renderables" should {
     "render simple lambdas using placeholders when using scalaStyledRepr" in {
       val list = `LTT[_]`[List].scalaStyledRepr
@@ -43,6 +49,10 @@ class LTTRenderablesTest extends TagAssertions {
       assert(useInner == s"[A] ➾ izumi.reflect.test.OptionT[[A$expectedDepth] ➾ scala.util.Either[+A,+A$expectedDepth],A]")
       assert(useInner2 == s"[A,B] ➾ izumi.reflect.test.OptionT[[A$expectedDepth] ➾ scala.util.Either[+A,+A$expectedDepth],B]")
       assert(reuse == "[A] ➾ scala.util.Either[+A,+A]")
+    }
+
+    "types in nested objects should be rendered with dot separator" in {
+      assert(LTT[X.Y.C].scalaStyledRepr == "izumi.reflect.test.LTTRenderablesTest.X.Y.C")
     }
   }
 


### PR DESCRIPTION
Regression was introduced in https://github.com/zio/izumi-reflect/pull/556