### PR TITLE
docs: add PROJECT_BADGES to documentation index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,5 @@ title: "Introduction to izumi-reflect"
 sidebar_label: "izumi-reflect"
 ---
 
+@PROJECT_BADGES@
+


### PR DESCRIPTION
Add @PROJECT_BADGES@ variable to docs/index.md to display project badges on the documentation website introduction page, consistent with other ZIO ecosystem projects.

Fixes #545