### PR TITLE
Fix #481: Subtype relation for refined type fails

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -232,9 +232,12 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
 
   private[this] def makeAppliedBases(mainTpe: Type, allReferenceComponents: Iterator[Type]): List[(AbstractReference, AbstractReference)] = {
 
-    val appliedBases = allReferenceComponents
+    val components = allReferenceComponents
       .filterNot(isHKTOrPolyTypeOrResultTypeArtifact) // remove PolyTypes, only process applied types in this inspection
       .filterNot(isExistentialArtifact) // remove forSome artifacts in Scala 2.11 && 2.12
+      .toList
+
+    val appliedBases = components.iterator
       .flatMap {
         component =>
           val tparams = component.etaExpand.typeParams
@@ -267,8 +270,52 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
           parent == t
       }
       .toList
+
+    // Issue #481: Synthesize Refinement parent entries for named types with concrete type member overrides.
+    // When `trait AInt extends A { type T = Int }`, we add `AInt -> Refinement(A, {TypeMember(T, Int)})`
+    // to the basesdb, so that `AInt <:< A { type T = Int }` succeeds at runtime.
+    val refinementBases = components.iterator
+      .flatMap {
+        component =>
+          val concreteTypeMembers = getConcreteTypeMemberDecls(component)
+          if (concreteTypeMembers.isEmpty) {
+            Nil
+          } else {
+            val componentRef = makeRef(component)
+            val decls: Set[RefinementDecl] = concreteTypeMembers.map {
+              sym =>
+                val tpe = UniRefinement.typeOfTypeMember(sym)
+                val declName = sym.name.decodedName.toString
+                val ref = makeRef(tpe) match {
+                  case n @ NameReference(SymTypeName("<none>"), _, _) => n.copy(ref = SymTypeName(declName))
+                  case ref => ref
+                }
+                RefinementDecl.TypeMember(declName, ref): RefinementDecl
+            }.toSet
+
+            if (decls.nonEmpty) {
+              val appliedParents = tpeBases(component).filterNot(isHKTOrPolyTypeOrResultTypeArtifact)
+              appliedParents.map {
+                parentTpe =>
+                  val parentRef = makeRef(parentTpe).asInstanceOf[AppliedReference]
+                  (componentRef, Refinement(parentRef, decls): AbstractReference)
+              }
+            } else {
+              Nil
+            }
+          }
+      }
+      .filterNot {
+        case (t, parent) =>
+          parent == t
+      }
+      .toList
+
     logger.log(s"Computed applied bases for tpe=$mainTpe appliedBases=${appliedBases.toMultimap.niceList()}")
-    appliedBases
+    if (refinementBases.nonEmpty) {
+      logger.log(s"Computed refinement bases for tpe=$mainTpe refinementBases=${refinementBases.toMultimap.niceList()}")
+    }
+    appliedBases ++ refinementBases
   }
 
   private[this] def makeLambdaOnlyBases(mainTpe: Type, allReferenceComponents: Iterator[Type]): List[(AbstractReference, AbstractReference)] = {
@@ -410,6 +457,30 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
       .filterNot(ignored)
       .filterNot(if (isSingletonType(tpe)) _ => false else _.typeSymbol.fullName == tpe.typeSymbol.fullName)
       .filterNot(_ =:= tpe) // 2.11/2.12 fail this
+      .toList
+  }
+
+  /** Issue #481: Get concrete type member declarations of a type.
+   *  A type member is concrete when its lower and upper bounds are equal (type T = X),
+   *  meaning it's a type alias or a fully-defined type member override.
+   *  This is used to synthesize Refinement parent entries in the basesdb. */
+  private[this] def getConcreteTypeMemberDecls(tpe: Type): List[Symbol] = {
+    val dealiased = Dealias.fullNormDealias(tpe)
+    dealiased.typeSymbol.typeSignature.decls.iterator
+      .filter(sym => sym.isType && !sym.isClass)
+      .filter { sym =>
+        val sig = sym.typeSignature
+        // Only include non-higher-kinded concrete type members (type T = X)
+        !sig.takesTypeArgs && (sig match {
+          case b: TypeBoundsApi =>
+            // Concrete: lo =:= hi (type T = X is TypeBounds(X, X))
+            // Exclude trivially abstract: Nothing..Any
+            b.lo =:= b.hi && !(b.lo =:= nothing && b.hi =:= any)
+          case _ =>
+            // Not bounds type, it's a type alias
+            true
+        })
+      }
       .toList
   }
 

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
@@ -183,7 +183,55 @@ abstract class FullDbInspector(protected val shift: Int) extends InspectorBase {
 
       val mainBasesRefs = recursiveParentRefs ::: directBaseRefs
 
-      argBasesRefs ::: mainBasesRefs
+      // Issue #481: Synthesize Refinement parent entries for named types with concrete type member overrides.
+      // When `trait AInt extends A { type T = Int }`, we add `AInt -> Refinement(A, {TypeMember(T, Int)})`
+      // to the basesdb, so that `AInt <:< A { type T = Int }` succeeds at runtime.
+      val refinementBasesRefs = if (onlyIndirect) {
+        Nil
+      } else {
+        val sym = tpe.typeSymbol
+        if (sym.isClassDef) {
+          val concreteTypeMembers = sym.declarations.filter { decl =>
+            decl.isTypeDef && !decl.isClassDef && {
+              tpe.memberType(decl) match {
+                case tb: TypeBounds =>
+                  // Concrete: lo =:= hi (type T = X is TypeBounds(X, X))
+                  // Exclude trivially abstract: Nothing..Any
+                  (tb.low =:= tb.hi) && !(tb.low =:= defn.NothingClass.typeRef && tb.hi =:= defn.AnyClass.typeRef)
+                case _ =>
+                  true // type alias
+              }
+            }
+          }
+          if (concreteTypeMembers.isEmpty) {
+            Nil
+          } else {
+            val decls: Set[RefinementDecl] = concreteTypeMembers.map { decl =>
+              val declName = decl.name
+              val memberType = tpe.memberType(decl)
+              val ref = memberType match {
+                case tb: TypeBounds if tb.low =:= tb.hi =>
+                  inspector.inspectTypeRepr(tb.hi)
+                case other =>
+                  inspector.inspectTypeRepr(other)
+              }
+              RefinementDecl.TypeMember(declName, ref): RefinementDecl
+            }.toSet
+            if (decls.nonEmpty) {
+              baseTypes.map { bt =>
+                val parentRef = inspector.inspectTypeRepr(bt).asInstanceOf[AppliedReference]
+                (selfRef, LightTypeTagRef.Refinement(parentRef, decls): AbstractReference)
+              }
+            } else {
+              Nil
+            }
+          }
+        } else {
+          Nil
+        }
+      }
+
+      argBasesRefs ::: mainBasesRefs ::: refinementBasesRefs
     }
 
     private def inspectTypeBoundsToFull(tpe: TypeRepr): List[(AbstractReference, AbstractReference)] = {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -933,6 +933,24 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       assertChildStrict(t1, t2)
     }
 
+    "support subtype check of named type against refinement with type member override (issue #481)" in {
+      trait A481 { type T }
+      trait AInt481 extends A481 { type T = Int }
+      trait AString481 extends A481 { type T = String }
+
+      // Core bug fix: named type <:< refinement type with concrete type member
+      assertChild(LTT[AInt481], LTT[A481 { type T = Int }])
+      assertChild(LTT[AString481], LTT[A481 { type T = String }])
+
+      // Negative cases: wrong type member value
+      assertNotChild(LTT[AInt481], LTT[A481 { type T = String }])
+      assertNotChild(LTT[AString481], LTT[A481 { type T = Int }])
+
+      // Named type is still child of base type without refinement
+      assertChild(LTT[AInt481], LTT[A481])
+      assertChild(LTT[AString481], LTT[A481])
+    }
+
     "support human-readable representation" in {
       type TX[B] = Int { def a(k: String): Int; val b: String; type M1 = W1; type M2 <: W2; type M3[A] = Either[B, A] }
       val txTag = `LTT[_]`[TX]


### PR DESCRIPTION
/claim #481

## Problem

When a named type (e.g. `AInt`) extends a parent (e.g. `A`) with concrete type member overrides (e.g. `type T = Int`), the subtype check `Tag[AInt].tag <:< Tag[A { type T = Int }].tag` incorrectly returned `false`.

## Root Cause

The Scala 2 macro (`makeAppliedBases`) only stored `AInt -> A` in the `basesdb`. When `isChild` checked `AInt` against `Refinement(A, {TypeMember(T, Int)})`, it found no matching parent via `oneOfParameterizedParentsIsInheritedFrom`.

## Fix

Synthesize `Refinement` parent entries in the `basesdb` for named types with concrete type member overrides. When `trait AInt extends A { type T = Int }`, the basesdb now includes both `A` and `Refinement(A, {TypeMember(T, Int)})` as parents, allowing the existing comparison logic to find the match.

### Changes
- **`LightTypeTagImpl.scala`**: Added `getConcreteTypeMemberDecls()` helper + refinement synthesis in `makeAppliedBases()`
- **`SharedLightTypeTagTest.scala`**: Added regression test covering positive and negative cases

### Test Results (Scala 2.13)
```
Tests: succeeded 211, failed 0
All tests passed.
```

**Payout Wallet**: Dv4QWv74JaAWuQPecptgTDsfYnSw5HKwYuCMNaG6CxFM