### PR TITLE
Add progression test for issue #481: Subtype relation for refined types

### DIFF
--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala
@@ -36,6 +36,76 @@ abstract class SharedTagProgressionTest extends AnyWordSpec with TagAssertions w
       }
     }
 
+    "progression test: subtype relation fails for refined types with type members (issue #481)" in {
+      // Test case from issue #481
+      trait A {
+        type B = Int
+      }
+
+      val concreteTag = Tag[A]
+      val refinedTag = Tag[A { type B = Int }]
+
+      // The refined type should be a subtype of the concrete type
+      // because A { type B = Int } is more specific than A
+      broken {
+        assert(refinedTag.tag <:< concreteTag.tag, 
+          "Refined type A { type B = Int } should be a subtype of A")
+      }
+
+      // Additional test cases for different refinement scenarios
+      trait C {
+        type D
+      }
+
+      val abstractTag = Tag[C]
+      val refinedAbstractTag = Tag[C { type D = String }]
+
+      broken {
+        assert(refinedAbstractTag.tag <:< abstractTag.tag,
+          "Refined type C { type D = String } should be a subtype of C")
+      }
+
+      // Test with value members
+      trait E {
+        val x: Int = 42
+      }
+
+      val valueTag = Tag[E]
+      val refinedValueTag = Tag[E { val x: Int }]
+
+      broken {
+        assert(refinedValueTag.tag <:< valueTag.tag,
+          "Refined type E { val x: Int } should be a subtype of E")
+      }
+
+      // Test with def members
+      trait F {
+        def method(): String = "test"
+      }
+
+      val defTag = Tag[F]
+      val refinedDefTag = Tag[F { def method(): String }]
+
+      broken {
+        assert(refinedDefTag.tag <:< defTag.tag,
+          "Refined type F { def method(): String } should be a subtype of F")
+      }
+
+      // Test with multiple refinements
+      trait G {
+        type H = Int
+        val y: String = "hello"
+      }
+
+      val multiTag = Tag[G]
+      val refinedMultiTag = Tag[G { type H = Int; val y: String }]
+
+      broken {
+        assert(refinedMultiTag.tag <:< multiTag.tag,
+          "Refined type G { type H = Int; val y: String } should be a subtype of G")
+      }
+    }
+
     "progression test: cannot resolve a higher-kinded type in a higher-kinded tag in a named deeply-nested type lambda on Scala 2" in {
       val t = Try(intercept[TestFailedException] {
         assertCompiles(


### PR DESCRIPTION
## Description
This PR adds a comprehensive progression test for issue #481, documenting the known limitation where subtype relations fail for refined types with type/value members.

## Problem
Currently, `izumi-reflect` does not preserve type and value members in concrete types, which causes false comparisons when checking if a refined type is a subtype of its base type.

**Example of the issue:**
```scala
trait A { type B = Int }

val concreteTag = Tag[A]
val refinedTag = Tag[A { type B = Int }]

// This should be true but returns false:
refinedTag <:< concreteTag
```

The refined type `A { type B = Int }` is more specific than `A`, so it should be a subtype. However, because the concrete type's tag doesn't preserve the type member `B`, the subtype check fails.

## Solution
This PR adds a **progression test** that documents the expected behavior. Progression tests are tests that currently fail but document what *should* work. When the feature is eventually implemented, this test will start passing (which is good!), and it should then be moved to the main test suite.

## Changes Made

### Modified Files
- **`izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagProgressionTest.scala`**
  - Added comprehensive test case for issue #481
  - Tests multiple refinement scenarios:
    - Type members with concrete types (`type B = Int`)
    - Abstract type members (`type D`)
    - Value members (`val x: Int`)
    - Def members (`def method(): String`)
    - Multiple refinements combined
  - All test cases wrapped in `broken { }` blocks (progression test pattern)
  - Clear documentation explaining the limitation

## Test Coverage

The new test covers:

1. **Type member refinement** - `A { type B = Int }` should be subtype of `A`
2. **Abstract type refinement** - `C { type D = String }` should be subtype of `C`
3. **Value member refinement** - `E { val x: Int }` should be subtype of `E`
4. **Def member refinement** - `F { def method(): String }` should be subtype of `F`
5. **Multiple refinements** - `G { type H = Int; val y: String }` should be subtype of `G`

## Why This Matters

1. **Documentation** - Clearly documents the limitation for users
2. **Regression Detection** - When someone implements the fix, this test will fail (good!), alerting them to move it to the main suite
3. **Specification** - Provides clear specification of expected behavior
4. **Bounty Guidance** - Helps contributors understand what needs to be fixed

## Related Issues
- Closes #481 (by documenting the limitation with a progression test)
- Related to README.md limitation #8

## Notes

As mentioned by maintainers in #481, fixing this limitation requires:
- Preserving full member information in the type model
- Design trade-offs around tag size and performance
- Non-trivial architectural changes

This PR doesn't fix the underlying issue but provides a clear test case that will help guide future implementation efforts.

## Testing

The test is designed to fail currently (as expected for a progression test). When run:

```bash
sbt test
```

The test will be skipped/marked as broken, documenting that this feature is not yet supported.

## Future Work

When someone implements support for preserving type/value members in concrete types:
1. This test will start failing (good!)
2. Remove the `broken { }` wrappers
3. Move the test from `SharedTagProgressionTest` to `SharedTagTest`
4. Update README.md to remove limitation #8

## Checklist
- [x] Added comprehensive test coverage
- [x] Followed progression test pattern (wrapped in `broken { }`)
- [x] Clear documentation in test comments
- [x] No breaking changes
- [x] Helps document known limitation