### PR TITLE
fix: support variance for type parameters of opaque types in Scala 3 (Issue #548)

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
@@ -77,8 +77,15 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
           case Nil =>
             makeNameReferenceFromType(tycon)
           case _ =>
-            val symbolVariances: List[Variance] = tycon.typeSymbol.declaredTypes.collect {
+            // First try declaredTypes (works for regular types)
+            var symbolVariances: List[Variance] = tycon.typeSymbol.declaredTypes.collect {
               case s if s.isTypeParam => extractVariance(s)
+            }
+            // For opaque types, declaredTypes is empty, so we need to get variance from the type parameters directly
+            if (symbolVariances.isEmpty && tycon.typeSymbol.isOpaqueAlias) {
+              symbolVariances = tycon.typeSymbol.typeParams.collect {
+                case s if s.isTypeParam => extractVariance(s)
+              }
             }
             val variances: List[Variance] = if (symbolVariances.sizeCompare(appliedType.args) < 0) {
               tycon match {


### PR DESCRIPTION
## Summary

Fixes issue #548 - Scala 3: support variance reading for opaque types

## Problem

For opaque type aliases in Scala 3, `declaredTypes` returns an empty list because the type parameters are not 'declared' in the traditional sense. This caused variance detection to fail:

```scala
object x {
  opaque type T[+X] = X
}
// Expected: x.T[+Int] (covariant)
// Actual: x.T[Int] (invariant)
```

## Solution

Added a fallback to use `typeSymbol.typeParams` to extract variance information when `declaredTypes` is empty and the symbol is an opaque alias.

```scala
if (symbolVariances.isEmpty && tycon.typeSymbol.isOpaqueAlias) {
  symbolVariances = tycon.typeSymbol.typeParams.collect {
    case s if s.isTypeParam => extractVariance(s)
  }
}
```

## Testing

This fix enables correct variance detection for opaque types in Scala 3.