### PR TITLE
Fix subtype checking for refined types with type members

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -243,7 +243,7 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
           val appliedParents = tpeBases(component).filterNot(isHKTOrPolyTypeOrResultTypeArtifact)
           val componentRef = makeRef(component)
 
-          appliedParents.map {
+          val regularBases = appliedParents.map {
             parentTpe =>
               val parentRef = makeRefTop(parentTpe, terminalNames = lambdaParams, isLambdaOutput = lambdaParams.nonEmpty) match {
                 case unapplied: Lambda =>
@@ -260,6 +260,37 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
               }
               (componentRef, parentRef)
           }
+
+          // For types with declared type members, add synthetic Refinement parents to basesdb.
+          // This enables runtime subtype checks like `AInt <:< A { type T = Int }` where AInt
+          // concretely defines `type T = Int`. Without this, the runtime checker has no way to
+          // know that AInt satisfies the refinement `A { type T = Int }`.
+          // Note: we must use unfiltered base types here (including Object/Any) because
+          // `tpeBases` filters them via `ignored`, but refinement types like `{ type A }`
+          // desugar to `Object { type A }` and need Object as the base reference.
+          val typeMemberBases = {
+            val typeMemDecls = extractTypeMemberDecls(component)
+            if (typeMemDecls.nonEmpty) {
+              val declSet: Set[RefinementDecl] = typeMemDecls.toSet
+              val tpeNorm = Dealias.fullNormDealias(component)
+              val allBaseTypes = tpeNorm.baseClasses.iterator
+                .map(tpeNorm.baseType)
+                .filterNot(_.typeSymbol.fullName == tpeNorm.typeSymbol.fullName)
+                .filterNot(_ =:= tpeNorm)
+              allBaseTypes.flatMap { parentTpe =>
+                makeRef(parentTpe) match {
+                  case applied: AppliedReference =>
+                    Some((componentRef, LightTypeTagRef.Refinement(applied, declSet)))
+                  case _ =>
+                    None
+                }
+              }.toList
+            } else {
+              Nil
+            }
+          }
+
+          regularBases ++ typeMemberBases
       }
       .filterNot {
         case (t, parent) =>
@@ -425,6 +456,25 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
       }
     } else {
       makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)
+    }
+  }
+
+  /** Extract type member declarations from a class/trait type for use as synthetic Refinement parents in basesdb.
+    * This enables runtime subtype checks like `AInt <:< A { type T = Int }` where AInt
+    * concretely defines `type T = Int`. Reuses the same `<none>` replacement logic as convertDecl.
+    */
+  private[this] def extractTypeMemberDecls(tpe: Type): List[RefinementDecl.TypeMember] = {
+    val tpeSig = tpe.typeSymbol.typeSignature
+    val typeParams = tpeSig.typeParams.toSet
+    val typeMembers = tpeSig.decls.filter(s => s.isType && !s.isClass && !typeParams.contains(s)).toList
+    typeMembers.flatMap { sym =>
+      val memberTpe = UniRefinement.typeOfTypeMember(sym)
+      val declName = sym.name.decodedName.toString
+      val ref = makeRef(memberTpe) match {
+        case n @ NameReference(SymName.SymTypeName("<none>"), _, _) => n.copy(ref = SymName.SymTypeName(declName))
+        case ref => ref
+      }
+      Some(RefinementDecl.TypeMember(declName, ref))
     }
   }
 

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
@@ -181,7 +181,26 @@ abstract class FullDbInspector(protected val shift: Int) extends InspectorBase {
         }
       }
 
-      val mainBasesRefs = recursiveParentRefs ::: directBaseRefs
+      // For types with declared type members, add synthetic Refinement parents to basesdb.
+      // This enables runtime subtype checks like `AInt <:< A { type T = Int }` where AInt
+      // concretely defines `type T = Int`. Without this, the runtime checker has no way to
+      // know that AInt satisfies the refinement `A { type T = Int }`.
+      val typeMemberRefs = if (onlyIndirect) {
+        Nil
+      } else {
+        val typeMemDecls = inspector.extractTypeMemberDecls(tpe)
+        if (typeMemDecls.isEmpty) {
+          Nil
+        } else {
+          val declSet: Set[RefinementDecl] = typeMemDecls.toSet
+          baseTypes.map { bt =>
+            val parentRef = inspector.inspectTypeRepr(bt).asInstanceOf[AppliedReference]
+            (selfRef, LightTypeTagRef.Refinement(parentRef, declSet))
+          }
+        }
+      }
+
+      val mainBasesRefs = recursiveParentRefs ::: directBaseRefs ::: typeMemberRefs
 
       argBasesRefs ::: mainBasesRefs
     }

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/Inspector.scala
@@ -209,6 +209,30 @@ abstract class Inspector(protected val shift: Int, val context: Queue[Inspector.
     LightTypeTagRef.Refinement(ohOh, refinementDecls.toSet)
   }
 
+  /** Extract type member declarations from a class/trait type for use as synthetic Refinement parents in basesdb.
+    * This reuses the same logic as inspectRefinements for converting TypeBounds to RefinementDecl.TypeMember.
+    */
+  private[dottyreflection] def extractTypeMemberDecls(tpe: TypeRepr): List[RefinementDecl.TypeMember] = {
+    val typeMembers = tpe.typeSymbol.declaredTypes.filterNot(s => s.isTypeParam || s.isClassDef)
+    typeMembers.flatMap { sym =>
+      tpe.memberType(sym) match {
+        case bounds: TypeBounds =>
+          val boundaries = next().inspectBoundsImpl(bounds)
+          val res = boundaries match {
+            case Boundaries.Defined(low, high) if high == low =>
+              // concrete type member: type T = Int
+              high
+            case definedBoundaries =>
+              // abstract type member: type T >: A <: B or type T
+              NameReference(SymName.SymTypeName(sym.name), definedBoundaries, None)
+          }
+          Some(RefinementDecl.TypeMember(sym.name, res))
+        case _ =>
+          None
+      }
+    }
+  }
+
   private def inspectBounds(outerTypeRef: Option[TypeRef], tb: TypeBounds): AbstractReference = {
     log(s"inspectBounds: found TypeBounds $tb outer=$outerTypeRef")
     val boundaries = inspectBoundsImpl(tb)

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagProgressionTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagProgressionTest.scala
@@ -64,11 +64,9 @@ abstract class SharedLightTypeTagProgressionTest extends TagAssertions with TagP
       assertChild(`LTT[A,B,_>:B<:A]`[H3, H3, X1], `LTT[A,B,_>:B<:A]`[H2, H4, X])
     }
 
-    "progression test: indirect structural checks do not work" in {
+    "indirect structural checks now work (was progression test)" in {
       assertDifferent(LTT[{ type A }], LTT[Object])
-      broken {
-        assertChildStrict(LTT[C], LTT[{ type A }])
-      }
+      assertChildStrict(LTT[C], LTT[{ type A }])
     }
 
     "progression test: combined intersection lambda tags still contain some junk bases (coming from the unsound same-arity assumption in LightTypeTag#combine)" in {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -918,6 +918,19 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       assertNotChildStrict(LTT[{ def T: Int }], LTT[{ type T }])
     }
 
+    "support indirect structural subtype checks (issue #481)" in {
+      // A concrete type that overrides an abstract type member should be a subtype of
+      // a refinement type that specifies the same concrete type member value.
+      assertChild(LTT[RefinedAInt], LTT[RefinedA { type T = Int }])
+      // Soundness: must NOT match a different type member value
+      assertNotChild(LTT[RefinedAInt], LTT[RefinedA { type T = String }])
+      // A different concrete override should match its own value
+      assertChild(LTT[RefinedAString], LTT[RefinedA { type T = String }])
+      assertNotChild(LTT[RefinedAString], LTT[RefinedA { type T = Int }])
+      // Check against unparameterized parent: a class with type A should be subtype of { type A }
+      assertChild(LTT[C], LTT[{ type A }])
+    }
+
     "what about non-empty refinements with intersections" in {
       val ltt = LTT[Int with Object with Option[String] { def a: Boolean }]
       val debug = ltt.debug()

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
@@ -210,4 +210,9 @@ object TestModel {
   trait AbstractRole[F[_]]
   class TargetRole extends AbstractRole[Id]
 
+  // Test types for type member refinement checks (issue #481)
+  trait RefinedA { type T }
+  trait RefinedAInt extends RefinedA { type T = Int }
+  trait RefinedAString extends RefinedA { type T = String }
+
 }


### PR DESCRIPTION
## Summary

Fixes #481. `Tag[AInt].tag <:< Tag[A { type T = Int }].tag` now correctly returns `true` when `AInt` concretely defines `type T = Int`.

**Root cause:** When `Tag[AInt]` is created at compile time, the macro stores `AInt -> A` in basesdb but does not record type member information. At runtime, `isChild(AInt, Refinement(A, {type T = Int}))` looks up basesdb for a Refinement parent of `AInt`, finds none, and returns `false`.

**Fix:** During macro expansion, for any type with declared type members, add synthetic `Refinement(parent, typeMembers)` entries to basesdb for each base type. The existing runtime case `(s: AbstractReference, t: Refinement) => oneOfParameterizedParentsIsInheritedFrom(ctx)(s, t)` then finds these entries and the check succeeds. No changes to the runtime checker were needed.

**Why PR #577's approach is unsound:** That PR adds `ctx.isChild(s, t.reference)` which strips all refinement declarations, making `AInt <:< A { type T = String }` also return `true` — a soundness violation. This PR preserves the full refinement information.

## Changes

- **Scala 3** (`Inspector.scala`, `FullDbInspector.scala`): Extract declared type members via `declaredTypes`, add synthetic Refinement parents in `extractBase`
- **Scala 2** (`LightTypeTagImpl.scala`): Same approach using `typeSignature.decls` and `typeOfTypeMember`, with unfiltered base types (since `tpeBases` filters Object/Any but refinements like `{ type A }` desugar to `Object { type A }`)
- **Tests**: Regression tests with both positive (`AInt <:< A { type T = Int }`) and negative soundness checks (`AInt !<:< A { type T = String }`). Former progression test for `C <:< { type A }` now passes.

## Test results

| Version | Tests | Result |
|---------|-------|--------|
| Scala 3.3.6 | 210 | All passed |
| Scala 2.13.14 | 211 | All passed |
| Scala 2.12.20 | 209 | All passed |
| Scala 2.11.12 | 209 | All passed |