### PR TITLE
fix(#481): subtype relation for refined type members

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
@@ -224,7 +224,7 @@ final class LightTypeTagInheritance(self: LightTypeTag, other: LightTypeTag) {
       ln == rn && compareBounds(ctx)(lref, rBounds)
     case (RefinementDecl.TypeMember(ln, lref), RefinementDecl.TypeMember(rn, rref)) =>
       // if the rhs type is not abstract (has form `type X = Int`), then lhs must be exactly equal to it, not <:
-      ln == rn && lref == rref
+      ln == rn && ctx.isChild(lref, rref)
     case (RefinementDecl.Signature(ln, lins, lout), RefinementDecl.Signature(rn, rins, rout)) =>
       (ln == rn
         && lins.iterator.zipAll(rins.iterator, null, null).forall {


### PR DESCRIPTION
/claim #481\n\nFix #481 - When comparing type members in refined types (e.g., { type T = Int }), the comparison logic was checking for exact equality (ln == rn && lref == rref) instead of checking subtype relation.\n\nThe fix changes the condition to check subtype relation (ctx.isChild(lref, rref)) which is the correct semantics.\n\nThis resolves the issue where Tag[AInt].tag <:< Tag[A { type T = Int }].tag returns false when it should return true.