### PR TITLE
feat: add soft-reference compile-time caches

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -24,18 +24,43 @@ import izumi.reflect.internal.fundamentals.platform.assertions.IzAssert
 import izumi.reflect.internal.fundamentals.platform.console.TrivialLogger
 import izumi.reflect.internal.fundamentals.platform.console.TrivialLogger.Config
 import izumi.reflect.internal.fundamentals.platform.strings.IzString._
-import izumi.reflect.macrortti.LightTypeTagImpl.{Broken, globalCache}
+import izumi.reflect.macrortti.LightTypeTagImpl.Broken
 import izumi.reflect.macrortti.LightTypeTagRef.SymName.{SymLiteral, SymTermName, SymTypeName}
 import izumi.reflect.macrortti.LightTypeTagRef._
 import izumi.reflect.{DebugProperties, ReflectionUtil}
 
+import java.lang.ref.SoftReference
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.reflectiveCalls
 import scala.reflect.api.Universe
 
 object LightTypeTagImpl {
-  private lazy val globalCache = new java.util.WeakHashMap[Any, AbstractReference]
+  private lazy val refCache = new java.util.WeakHashMap[Any, SoftReference[AbstractReference]]
+  private lazy val fullDbCache = new java.util.WeakHashMap[Any, SoftReference[Map[AbstractReference, Set[AbstractReference]]]]
+  private lazy val inheritanceDbCache = new java.util.WeakHashMap[Any, SoftReference[Map[NameReference, Set[NameReference]]]]
+
+  private def cachedSoftReference[A <: AnyRef](cache: java.util.WeakHashMap[Any, SoftReference[A]])(key: Any)(compute: => A): A = {
+    cache.synchronized {
+      Option(cache.get(key)).flatMap(ref => Option(ref.get)).getOrElse {
+        val computed = compute
+        cache.put(key, new SoftReference[A](computed))
+        computed
+      }
+    }
+  }
+
+  private[macrortti] def cachedRef(key: Any)(compute: => AbstractReference): AbstractReference = {
+    cachedSoftReference(refCache)(key)(compute)
+  }
+
+  private[macrortti] def cachedFullDb(key: Any)(compute: => Map[AbstractReference, Set[AbstractReference]]): Map[AbstractReference, Set[AbstractReference]] = {
+    cachedSoftReference(fullDbCache)(key)(compute)
+  }
+
+  private[macrortti] def cachedInheritanceDb(key: Any)(compute: => Map[NameReference, Set[NameReference]]): Map[NameReference, Set[NameReference]] = {
+    cachedSoftReference(inheritanceDbCache)(key)(compute)
+  }
 
   /** caching is enabled by default for runtime light type tag creation */
   private[this] lazy val runtimeCacheEnabled: Boolean = {
@@ -97,10 +122,27 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
       .newBuilder[Type]
       .++= {
         allTypeReferencesWithBases(tpe, mutable.HashSet.empty, onlyIndirect = false)
-      }.result()
+      }.result().toList
 
-    val fullDb = makeFullDb(tpe, allReferenceComponents).toMultimap
-    val unappliedDb = makeClassOnlyInheritanceDb(tpe, allReferenceComponents.iterator)
+    def fullDb = {
+      if (withCache) {
+        LightTypeTagImpl.cachedFullDb(tpe) {
+          makeFullDb(tpe, allReferenceComponents).toMultimap
+        }
+      } else {
+        makeFullDb(tpe, allReferenceComponents).toMultimap
+      }
+    }
+
+    def unappliedDb = {
+      if (withCache) {
+        LightTypeTagImpl.cachedInheritanceDb(tpe) {
+          makeClassOnlyInheritanceDb(tpe, allReferenceComponents.iterator)
+        }
+      } else {
+        makeClassOnlyInheritanceDb(tpe, allReferenceComponents.iterator)
+      }
+    }
 
     LightTypeTag(lttRef, fullDb, unappliedDb)
   }
@@ -415,13 +457,8 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
 
   private[this] def makeRef(tpe: Type): AbstractReference = {
     if (withCache) {
-      globalCache.synchronized(globalCache.get(tpe)) match {
-        case null =>
-          val ref = makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)
-          globalCache.synchronized(globalCache.put(tpe, ref))
-          ref
-        case ref =>
-          ref
+      LightTypeTagImpl.cachedRef(tpe) {
+        makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)
       }
     } else {
       makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/TypeInspections.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/TypeInspections.scala
@@ -1,21 +1,70 @@
 package izumi.reflect.dottyreflection
 
+import izumi.reflect.DebugProperties
 import izumi.reflect.macrortti.LightTypeTagRef.{AbstractReference, NameReference}
 
-import scala.quoted.{Quotes, Type}
-import scala.collection.immutable.Queue
+import java.lang.ref.SoftReference
+import scala.collection.mutable
+import scala.quoted.Quotes
 
 object TypeInspections {
+  private val refCache = mutable.HashMap.empty[String, SoftReference[AbstractReference]]
+  private val fullDbCache = mutable.HashMap.empty[String, SoftReference[Map[AbstractReference, Set[AbstractReference]]]]
+  private val unappliedDbCache = mutable.HashMap.empty[String, SoftReference[Map[NameReference, Set[NameReference]]]]
+
+  private def cacheEnabled: Boolean = {
+    Option(System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`))
+      .map(_.trim.toLowerCase)
+      .collect {
+        case "true" => true
+        case "false" => false
+      }
+      .getOrElse(true)
+  }
+
+  private def cacheKey(using qctx: Quotes)(typeRepr: qctx.reflect.TypeRepr): String = {
+    import qctx.reflect.*
+    s"${typeRepr.hashCode()}::${typeRepr.show(using Printer.TypeReprStructure)}"
+  }
+
+  private def cached[A <: AnyRef](cache: mutable.HashMap[String, SoftReference[A]])(key: String)(compute: => A): A = {
+    cache.synchronized {
+      cache.get(key).flatMap(ref => Option(ref.get)).getOrElse {
+        val computed = compute
+        cache.put(key, new SoftReference[A](computed))
+        computed
+      }
+    }
+  }
+
   def apply(using qctx: Quotes)(typeRepr: qctx.reflect.TypeRepr): AbstractReference = {
-    Inspector.make(qctx).buildTypeRef(typeRepr)
+    if (cacheEnabled) {
+      cached(refCache)(cacheKey(typeRepr)) {
+        Inspector.make(qctx).buildTypeRef(typeRepr)
+      }
+    } else {
+      Inspector.make(qctx).buildTypeRef(typeRepr)
+    }
   }
 
   def unappliedDb(using qctx: Quotes)(typeRepr: qctx.reflect.TypeRepr): Map[NameReference, Set[NameReference]] = {
-    InheritanceDbInspector.make(qctx).makeUnappliedInheritanceDb(typeRepr)
+    if (cacheEnabled) {
+      cached(unappliedDbCache)(cacheKey(typeRepr)) {
+        InheritanceDbInspector.make(qctx).makeUnappliedInheritanceDb(typeRepr)
+      }
+    } else {
+      InheritanceDbInspector.make(qctx).makeUnappliedInheritanceDb(typeRepr)
+    }
   }
 
   def fullDb(using qctx: Quotes)(typeRepr: qctx.reflect.TypeRepr): Map[AbstractReference, Set[AbstractReference]] = {
-    FullDbInspector.make(qctx).buildFullDb(typeRepr)
+    if (cacheEnabled) {
+      cached(fullDbCache)(cacheKey(typeRepr)) {
+        FullDbInspector.make(qctx).buildFullDb(typeRepr)
+      }
+    } else {
+      FullDbInspector.make(qctx).buildFullDb(typeRepr)
+    }
   }
 
 }


### PR DESCRIPTION
This PR implements the soft-reference compile-time cache requested in #350 with a small, targeted patch.

What changed
- Scala 2: wraps compile-time caches for `ref`, `fullDb`, and `inheritanceDb` with `SoftReference`
- Scala 3: adds the corresponding soft-reference compile-time caches in `TypeInspections`
- Keeps the patch limited to 2 source files only

Validation
- Scala 3 TagTest: passed
- Scala 2 TagTest: passed
- cache disabled check: `-Dizumi.reflect.rtti.cache.compile=false` still passes TagTest
- full regression: `sbt +clean +test` passed (209 tests, 0 failed)

Notes
- I intentionally did not include unrelated changes
- I also did not add benchmark claims from weak single-run samples; this PR focuses on requested behavior and regression safety

Closes #350
