### PR TITLE
Fix #481: subtype check for refinement type members uses semantic equality

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
@@ -223,8 +223,22 @@ final class LightTypeTagInheritance(self: LightTypeTag, other: LightTypeTag) {
       // We know that the type is abstract if its name matches the type member's name
       ln == rn && compareBounds(ctx)(lref, rBounds)
     case (RefinementDecl.TypeMember(ln, lref), RefinementDecl.TypeMember(rn, rref)) =>
-      // if the rhs type is not abstract (has form `type X = Int`), then lhs must be exactly equal to it, not <:
-      ln == rn && lref == rref
+      // If the rhs type is not abstract (has form `type X = Int`), then lhs must
+      // be semantically equal to rhs — type-member assignments are invariant.
+      //
+      // Historically this case used `lref == rref` structural AST equality, but
+      // two AST forms can denote the same type while differing in incidental
+      // shape (presence/absence of an empty `Boundaries.Empty`, distinct prefix
+      // chains for the same symbol, refinement form vs. plain name reference for
+      // a fixed type member, etc.). That broke #481 — a trait overriding an
+      // abstract type member with a concrete one was not recognised as a subtype
+      // of the structural refinement form fixing the same type member.
+      //
+      // Mutual subtyping is the principled invariant-equality check: two refs
+      // denote the same type iff each is a subtype of the other. We keep the
+      // `lref == rref` fast-path so the common case stays cheap and we avoid
+      // recursing into `isChild` when not necessary.
+      ln == rn && (lref == rref || (ctx.isChild(lref, rref) && ctx.isChild(rref, lref)))
     case (RefinementDecl.Signature(ln, lins, lout), RefinementDecl.Signature(rn, rins, rout)) =>
       (ln == rn
         && lins.iterator.zipAll(rins.iterator, null, null).forall {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -918,6 +918,26 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       assertNotChildStrict(LTT[{ def T: Int }], LTT[{ type T }])
     }
 
+    "regression test https://github.com/zio/izumi-reflect/issues/481 — trait overriding an abstract type member is a subtype of the structural refinement form" in {
+      // Direct repro from the issue body. With the bug, the second assertion fails
+      // because compareDecl on two TypeMember(_, lref) / TypeMember(_, rref) decls
+      // requires `lref == rref` structural equality on AST nodes, which can fail
+      // even when the two refs denote the same type semantically.
+      assertChild(LTT[Issue481AInt], LTT[Issue481A { type T = Int }])
+      assertChild(LTT[Issue481AStr], LTT[Issue481A { type T = String }])
+
+      // Negative direction must still hold: AInt is NOT a subtype of A { type T = String }.
+      assertNotChild(LTT[Issue481AInt], LTT[Issue481A { type T = String }])
+      assertNotChild(LTT[Issue481AStr], LTT[Issue481A { type T = Int }])
+
+      // A trait fixing `type T = Int` is a subtype of structural refinements with
+      // an upper-bounded abstract type member (already worked pre-fix, but kept
+      // here to guard against regressions in adjacent paths).
+      assertChild(LTT[Issue481AInt], LTT[Issue481A { type T <: AnyVal }])
+      assertChild(LTT[Issue481AInt], LTT[Issue481A { type T <: Any }])
+      assertNotChild(LTT[Issue481AStr], LTT[Issue481A { type T <: AnyVal }])
+    }
+
     "what about non-empty refinements with intersections" in {
       val ltt = LTT[Int with Object with Option[String] { def a: Boolean }]
       val debug = ltt.debug()

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
@@ -108,6 +108,19 @@ object TestModel {
   type WithX = { type X }
   type FXS <: { type F[A] = A }
 
+  // Regression: https://github.com/zio/izumi-reflect/issues/481
+  // A trait that fixes an inherited abstract type member must be a subtype of the
+  // structural form of its parent with the same type member fixed.
+  trait Issue481A {
+    type T
+  }
+  trait Issue481AInt extends Issue481A {
+    override type T = Int
+  }
+  trait Issue481AStr extends Issue481A {
+    override type T = String
+  }
+
   trait H1
   trait H2 extends H1
   trait H3 extends H2


### PR DESCRIPTION
/claim #481

## What

Fixes the long-standing #481 regression: a trait that fixes an inherited abstract
type member should be a subtype of the structural refinement form fixing the
same member, but `Tag[AInt].tag <:< Tag[A { type T = Int }].tag` was returning
`false`.

## Why

`LightTypeTagInheritance.compareDecl` compared two `RefinementDecl.TypeMember`
declarations with `lref == rref` — strict structural AST equality. Two refs can
denote the same type while differing in incidental shape (presence/absence of an
empty `Boundaries.Empty`, distinct prefix chains for the same symbol, refinement
form vs. plain `NameReference` for a fixed type member, etc.), so the `==`
short-circuited to `false` and a perfectly valid subtype relation was lost.

## How

Mutual subtyping is the principled invariant-equality check: two refs denote the
same type iff each is a subtype of the other. Keep the `==` fast-path so the
common case stays cheap.

```scala
case (RefinementDecl.TypeMember(ln, lref), RefinementDecl.TypeMember(rn, rref)) =>
  ln == rn && (lref == rref || (ctx.isChild(lref, rref) && ctx.isChild(rref, lref)))