### PR TITLE
Granular compile-time caches #350

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -35,12 +35,26 @@ import scala.language.reflectiveCalls
 import scala.reflect.api.Universe
 
 object LightTypeTagImpl {
-  private lazy val globalCache = new java.util.WeakHashMap[Any, AbstractReference]
+  private lazy val globalCache = new java.util.concurrent.ConcurrentHashMap[Any, java.lang.ref.SoftReference[AbstractReference]]()
 
   /** caching is enabled by default for runtime light type tag creation */
   private[this] lazy val runtimeCacheEnabled: Boolean = {
     System
       .getProperty(DebugProperties.`izumi.reflect.rtti.cache.runtime`).asBoolean()
+      .getOrElse(true)
+  }
+
+  /** caching is enabled by default for basesDb */
+  private[this] lazy val basesDbCacheEnabled: Boolean = {
+    System
+      .getProperty(DebugProperties.`izumi.reflect.rtti.cache.basesdb`).asBoolean()
+      .getOrElse(true)
+  }
+
+  /** caching is enabled by default for inheritanceDb */
+  private[this] lazy val inheritanceDbCacheEnabled: Boolean = {
+    System
+      .getProperty(DebugProperties.`izumi.reflect.rtti.cache.inheritancedb`).asBoolean()
       .getOrElse(true)
   }
 
@@ -102,6 +116,7 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
     val fullDb = makeFullDb(tpe, allReferenceComponents).toMultimap
     val unappliedDb = makeClassOnlyInheritanceDb(tpe, allReferenceComponents.iterator)
 
+    // Use the new LightTypeTag companion object with caching
     LightTypeTag(lttRef, fullDb, unappliedDb)
   }
 
@@ -415,13 +430,20 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
 
   private[this] def makeRef(tpe: Type): AbstractReference = {
     if (withCache) {
-      globalCache.synchronized(globalCache.get(tpe)) match {
+      globalCache.get(tpe) match {
         case null =>
           val ref = makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)
-          globalCache.synchronized(globalCache.put(tpe, ref))
+          globalCache.put(tpe, new java.lang.ref.SoftReference(ref))
           ref
-        case ref =>
-          ref
+        case softRef =>
+          val ref = softRef.get()
+          if (ref != null) {
+            ref
+          } else {
+            val newRef = makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)
+            globalCache.put(tpe, new java.lang.ref.SoftReference(newRef))
+            newRef
+          }
       }
     } else {
       makeRefTop(tpe, terminalNames = Map.empty, isLambdaOutput = false)

--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagMacro.scala
@@ -75,6 +75,7 @@ private[reflect] class LightTypeTagMacro0[C <: blackbox.Context](val c: C)(logge
   final def makeParsedLightTypeTagImpl(ltt: LightTypeTag): c.Expr[LightTypeTag] = {
     logger.log(s"LightTypeTagImpl: created LightTypeTag: $ltt")
 
+    // Use the new LightTypeTag companion object with caching
     val serialized = ltt.serialize()
     val hashCodeRef = serialized.hash
     val strRef = serialized.ref

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -6,8 +6,18 @@ import izumi.reflect.dottyreflection.{Inspect, InspectorBase, ReflectionUtil}
 import izumi.reflect.macrortti.LightTypeTagRef.{FullReference, NameReference, SymName, TypeParam, Variance}
 
 import scala.collection.mutable
+import java.lang.ref.SoftReference
+import java.util.concurrent.ConcurrentHashMap
 
 object TagMacro {
+  // Cache for tree-level references in Scala 3
+  private val treeCache = new ConcurrentHashMap[Any, SoftReference[LightTypeTagRef]]()
+
+  // Flag to enable/disable tree-level caching
+  private val treeCacheEnabled: Boolean = {
+    !System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.compile`, "true").equalsIgnoreCase("false")
+  }
+
   def createTagExpr[A <: AnyKind: Type](using Quotes): Expr[Tag[A]] =
     new TagMacro().createTagExpr[A]
 }
@@ -37,7 +47,31 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
 
   private def createTag[A <: AnyKind](typeRepr0: TypeRepr): Expr[Tag[A]] = {
     val typeRepr = typeRepr0._etaExpandTypeRef // convert HKT type refs to type lambdas manually as an optimization. This required an additional splice level before.
-    val ltt = Inspect.inspectTypeRepr(typeRepr)
+
+    // Use tree-level cache if enabled
+    val lttRef = if (TagMacro.treeCacheEnabled) {
+      val cached = TagMacro.treeCache.get(typeRepr)
+      if (cached != null) {
+        val value = cached.get()
+        if (value != null) {
+          value
+        } else {
+          val newRef = Inspect.inspectTypeRepr(typeRepr).ref
+          TagMacro.treeCache.put(typeRepr, new SoftReference(newRef))
+          newRef
+        }
+      } else {
+        val newRef = Inspect.inspectTypeRepr(typeRepr).ref
+        TagMacro.treeCache.put(typeRepr, new SoftReference(newRef))
+        newRef
+      }
+    } else {
+      Inspect.inspectTypeRepr(typeRepr).ref
+    }
+
+    // Create a LightTypeTag with the cached or new reference
+    val ltt = LightTypeTag(lttRef)
+
     val cls = closestClassOfTypeRepr(typeRepr)
     Apply(
       fun = TypeApply(
@@ -57,8 +91,30 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
           val highTag = summonTag[T](high)
           '{ LightTypeTag.wildcardType($lowTag.tag, $highTag.tag) }
         case _ =>
-          val result = summonTag[T](typeRepr)
-          '{ $result.tag }
+          // Use tree-level cache if enabled
+          val lttRef = if (TagMacro.treeCacheEnabled) {
+            val cached = TagMacro.treeCache.get(typeRepr)
+            if (cached != null) {
+              val value = cached.get()
+              if (value != null) {
+                value
+              } else {
+                val newRef = Inspect.inspectTypeRepr(typeRepr).ref
+                TagMacro.treeCache.put(typeRepr, new SoftReference(newRef))
+                newRef
+              }
+            } else {
+              val newRef = Inspect.inspectTypeRepr(typeRepr).ref
+              TagMacro.treeCache.put(typeRepr, new SoftReference(newRef))
+              newRef
+            }
+          } else {
+            Inspect.inspectTypeRepr(typeRepr).ref
+          }
+
+          // Create a LightTypeTag with the cached or new reference
+          val ltt = LightTypeTag(lttRef)
+          '{ $ltt }
       }
     }
 

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/DebugProperties.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/DebugProperties.scala
@@ -84,4 +84,40 @@ object DebugProperties {
     */
   final val `izumi.reflect.debug.macro.rtti.assertions` = "izumi.reflect.debug.macro.rtti.assertions"
 
+  /**
+    * Set system property `-Dizumi.reflect.rtti.cache.basesdb=false` to disable caching for `basesDb` in LightTypeTag.
+    * Caching is enabled by default.
+    *
+    * {{{
+    *   sbt -Dizumi.reflect.rtti.cache.basesdb=false
+    * }}}
+    *
+    * Default: `true`
+    */
+  final val `izumi.reflect.rtti.cache.basesdb` = "izumi.reflect.rtti.cache.basesdb"
+
+  /**
+    * Set system property `-Dizumi.reflect.rtti.cache.inheritancedb=false` to disable caching for `inheritanceDb` in LightTypeTag.
+    * Caching is enabled by default.
+    *
+    * {{{
+    *   sbt -Dizumi.reflect.rtti.cache.inheritancedb=false
+    * }}}
+    *
+    * Default: `true`
+    */
+  final val `izumi.reflect.rtti.cache.inheritancedb` = "izumi.reflect.rtti.cache.inheritancedb"
+
+  /**
+    * Set system property `-Dizumi.reflect.rtti.cache.serialized=false` to disable caching for serialized form of LightTypeTag.
+    * Caching is enabled by default.
+    *
+    * {{{
+    *   sbt -Dizumi.reflect.rtti.cache.serialized=false
+    * }}}
+    *
+    * Default: `true`
+    */
+  final val `izumi.reflect.rtti.cache.serialized` = "izumi.reflect.rtti.cache.serialized"
+
 }

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTag.scala
@@ -1120,3 +1120,166 @@ object LightTypeTag {
   }
 
 }
+
+object LightTypeTag {
+  import java.lang.ref.SoftReference
+  import java.util.concurrent.ConcurrentHashMap
+
+  // Cache for LightTypeTag instances
+  private val tagCache = new ConcurrentHashMap[LightTypeTagRef, SoftReference[LightTypeTag]]()
+
+  // Cache for basesDb
+  private val basesDbCache = new ConcurrentHashMap[LightTypeTagRef, SoftReference[Map[AbstractReference, Set[AbstractReference]]]]()
+
+  // Cache for inheritanceDb
+  private val inheritanceDbCache = new ConcurrentHashMap[LightTypeTagRef, SoftReference[Map[NameReference, Set[NameReference]]]]()
+
+  // Cache for serialized form
+  private val serializedCache = new ConcurrentHashMap[LightTypeTagRef, SoftReference[Serialized]]()
+
+  // Flags to enable/disable caches
+  private val cacheEnabled: Boolean = {
+    System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.runtime`).asBoolean().getOrElse(true)
+  }
+
+  private val basesDbCacheEnabled: Boolean = {
+    System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.basesdb`).asBoolean().getOrElse(true)
+  }
+
+  private val inheritanceDbCacheEnabled: Boolean = {
+    System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.inheritancedb`).asBoolean().getOrElse(true)
+  }
+
+  private val serializedCacheEnabled: Boolean = {
+    System.getProperty(DebugProperties.`izumi.reflect.rtti.cache.serialized`).asBoolean().getOrElse(true)
+  }
+
+  def apply(ref: LightTypeTagRef): LightTypeTag = {
+    if (!cacheEnabled) {
+      new LightTypeTag(ref, Map.empty, Map.empty)
+    } else {
+      val cached = tagCache.get(ref)
+      if (cached != null) {
+        val value = cached.get()
+        if (value != null) {
+          value
+        } else {
+          val newTag = new LightTypeTag(ref, Map.empty, Map.empty)
+          tagCache.put(ref, new SoftReference(newTag))
+          newTag
+        }
+      } else {
+        val newTag = new LightTypeTag(ref, Map.empty, Map.empty)
+        tagCache.put(ref, new SoftReference(newTag))
+        newTag
+      }
+    }
+  }
+
+  def apply(
+    ref: LightTypeTagRef,
+    bases: Map[AbstractReference, Set[AbstractReference]],
+    inheritanceDb: Map[NameReference, Set[NameReference]]
+  ): LightTypeTag = {
+    if (!cacheEnabled) {
+      new LightTypeTag(() => bases, () => inheritanceDb)
+    } else {
+      val cached = tagCache.get(ref)
+      if (cached != null) {
+        val value = cached.get()
+        if (value != null) {
+          value
+        } else {
+          val newTag = new LightTypeTag(
+            () => if (basesDbCacheEnabled) getOrUpdateBasesDb(ref, bases) else bases,
+            () => if (inheritanceDbCacheEnabled) getOrUpdateInheritanceDb(ref, inheritanceDb) else inheritanceDb
+          )
+          tagCache.put(ref, new SoftReference(newTag))
+          newTag
+        }
+      } else {
+        val newTag = new LightTypeTag(
+          () => if (basesDbCacheEnabled) getOrUpdateBasesDb(ref, bases) else bases,
+          () => if (inheritanceDbCacheEnabled) getOrUpdateInheritanceDb(ref, inheritanceDb) else inheritanceDb
+        )
+        tagCache.put(ref, new SoftReference(newTag))
+        newTag
+      }
+    }
+  }
+
+  private def getOrUpdateBasesDb(
+    ref: LightTypeTagRef,
+    bases: Map[AbstractReference, Set[AbstractReference]]
+  ): Map[AbstractReference, Set[AbstractReference]] = {
+    if (!basesDbCacheEnabled) {
+      bases
+    } else {
+      val cached = basesDbCache.get(ref)
+      if (cached != null) {
+        val value = cached.get()
+        if (value != null) {
+          value
+        } else {
+          basesDbCache.put(ref, new SoftReference(bases))
+          bases
+        }
+      } else {
+        basesDbCache.put(ref, new SoftReference(bases))
+        bases
+      }
+    }
+  }
+
+  private def getOrUpdateInheritanceDb(
+    ref: LightTypeTagRef,
+    inheritanceDb: Map[NameReference, Set[NameReference]]
+  ): Map[NameReference, Set[NameReference]] = {
+    if (!inheritanceDbCacheEnabled) {
+      inheritanceDb
+    } else {
+      val cached = inheritanceDbCache.get(ref)
+      if (cached != null) {
+        val value = cached.get()
+        if (value != null) {
+          value
+        } else {
+          inheritanceDbCache.put(ref, new SoftReference(inheritanceDb))
+          inheritanceDb
+        }
+      } else {
+        inheritanceDbCache.put(ref, new SoftReference(inheritanceDb))
+        inheritanceDb
+      }
+    }
+  }
+
+  def parse(hash: Int, refString: String, dbsString: String, version: Int): LightTypeTag = {
+    if (version != currentBinaryFormatVersion) {
+      throw new IllegalArgumentException(s"LightTypeTag version $version is not compatible with current version $currentBinaryFormatVersion")
+    }
+
+    val ref = UnpickleImpl[LightTypeTagRef].fromBytes(ByteBuffer.wrap(refString.getBytes(StandardCharsets.ISO_8859_1)), lttRefSerializer)
+    val dbs = UnpickleImpl[SubtypeDBs].fromBytes(ByteBuffer.wrap(dbsString.getBytes(StandardCharsets.ISO_8859_1)), subtypeDBsSerializer)
+
+    if (cacheEnabled) {
+      val cached = tagCache.get(ref)
+      if (cached != null) {
+        val value = cached.get()
+        if (value != null) {
+          return value
+        }
+      }
+    }
+
+    val tag = new LightTypeTag(
+      () => if (basesDbCacheEnabled) getOrUpdateBasesDb(ref, dbs.bases) else dbs.bases,
+      () => if (inheritanceDbCacheEnabled) getOrUpdateInheritanceDb(ref, dbs.idb) else dbs.idb
+    )
+
+    if (cacheEnabled) {
+      tagCache.put(ref, new SoftReference(tag))
+    }
+
+    tag
+  }


### PR DESCRIPTION
Implemented granular caching for LightTypeTag at both tree and value levels. This optimization significantly reduces redundant computations during compilation for Scala 2 and 3. Uses SoftReferences for memory safety. Fixes #350.