### PR TITLE
Fix inherited type member refinement subtype checks

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-2/izumi/reflect/macrortti/LightTypeTagImpl.scala
@@ -243,7 +243,7 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
           val appliedParents = tpeBases(component).filterNot(isHKTOrPolyTypeOrResultTypeArtifact)
           val componentRef = makeRef(component)
 
-          appliedParents.map {
+          appliedParents.flatMap {
             parentTpe =>
               val parentRef = makeRefTop(parentTpe, terminalNames = lambdaParams, isLambdaOutput = lambdaParams.nonEmpty) match {
                 case unapplied: Lambda =>
@@ -258,7 +258,8 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
                 case applied: AppliedReference =>
                   applied
               }
-              (componentRef, parentRef)
+              val (refinedParent, typeMemberBaseRefs) = typeMemberRefinementParentAndBases(component, parentTpe, parentRef)
+              ((componentRef, parentRef) :: refinedParent.map(componentRef -> _).toList) ::: typeMemberBaseRefs
           }
       }
       .filterNot {
@@ -269,6 +270,113 @@ final class LightTypeTagImpl[U <: Universe with Singleton](val u: U, withCache: 
       .toList
     logger.log(s"Computed applied bases for tpe=$mainTpe appliedBases=${appliedBases.toMultimap.niceList()}")
     appliedBases
+  }
+
+  private[this] def typeMemberRefinementParentAndBases(
+    tpe: Type,
+    baseType: Type,
+    parentRef: AbstractReference
+  ): (Option[AbstractReference], List[(AbstractReference, AbstractReference)]) = {
+    val (typeMemberDecls, typeMemberBaseRefs) = baseType.decls.toList
+      .filter(symbol => symbol.isType && !symbol.isClass && !symbol.isParameter && symbol.isAbstract)
+      .flatMap {
+        member =>
+          typeMemberRefinementDecl(tpe, member)
+      }
+      .unzip
+
+    val decls: Set[RefinementDecl] = typeMemberDecls.toSet
+
+    parentRef match {
+      case parent: AppliedReference if decls.nonEmpty =>
+        (Some(Refinement(parent, decls)), typeMemberBaseRefs.flatten)
+      case _ =>
+        (None, typeMemberBaseRefs.flatten)
+    }
+  }
+
+  private[this] def typeMemberRefinementDecl(tpe: Type, member: Symbol): Option[(RefinementDecl.TypeMember, List[(AbstractReference, AbstractReference)])] = {
+    resolveTypeMember(tpe, member.name).flatMap {
+      member =>
+        val memberTpe = UniRefinement.typeOfTypeMember(member)
+        inspectTypeMember(member.name.decodedName.toString, memberTpe)
+    }
+  }
+
+  private[this] def resolveTypeMember(tpe: Type, name: Name): Option[Symbol] = {
+    val candidates = (tpe.decls.toList ++ tpe.baseClasses.map(tpe.baseType).flatMap(_.decls.toList))
+      .filter(symbol => symbol.isType && !symbol.isParameter && symbol.name == name)
+
+    candidates.find {
+      symbol =>
+        val memberTpe = UniRefinement.typeOfTypeMember(symbol)
+        nonEmptyTypeMember(memberTpe)
+    }
+  }
+
+  private[this] def nonEmptyTypeMember(memberTpe: Type): Boolean = {
+    memberTpe match {
+      case TypeBounds(lo, hi) =>
+        val low = makeRef(lo)
+        val high = makeRef(hi)
+        low != LightTypeTagInheritance.tpeNothing || high != LightTypeTagInheritance.tpeAny
+      case _ =>
+        true
+    }
+  }
+
+  private[this] def inspectTypeMember(name: String, memberTpe: Type): Option[(RefinementDecl.TypeMember, List[(AbstractReference, AbstractReference)])] = {
+    val memberBaseRefs = typeMemberComponentTypes(memberTpe).flatMap(typeMemberBases)
+
+    memberTpe match {
+      case TypeBounds(lo, hi) =>
+        val low = makeRef(lo)
+        val high = makeRef(hi)
+        val boundaries = if (low == LightTypeTagInheritance.tpeNothing && high == LightTypeTagInheritance.tpeAny) {
+          Boundaries.Empty
+        } else {
+          Boundaries.Defined(low, high)
+        }
+        boundaries match {
+          case Boundaries.Defined(boundLow, boundHigh) if boundLow == boundHigh =>
+            Some((RefinementDecl.TypeMember(name, boundHigh), memberBaseRefs))
+          case defined @ Boundaries.Defined(_, _) =>
+            Some((RefinementDecl.TypeMember(name, NameReference(SymTypeName(name), defined, None)), memberBaseRefs))
+          case Boundaries.Empty =>
+            None
+        }
+      case concrete =>
+        Some((RefinementDecl.TypeMember(name, makeRef(concrete)), memberBaseRefs))
+    }
+  }
+
+  private[this] def typeMemberComponentTypes(tpe: Type): List[Type] = {
+    tpe match {
+      case TypeBounds(lo, hi) =>
+        List(lo, hi).filterNot(ignored)
+      case concrete =>
+        List(concrete)
+    }
+  }
+
+  private[this] def typeMemberBases(tpe: Type): List[(AbstractReference, AbstractReference)] = {
+    def directBases(component0: Type): List[(AbstractReference, AbstractReference)] = {
+      val component = Dealias.fullNormDealias(component0)
+      val componentRef = makeRef(component)
+      tpeBases(component)
+        .filterNot(isHKTOrPolyTypeOrResultTypeArtifact)
+        .map(parent => componentRef -> makeRef(parent))
+    }
+
+    typeMemberComponentTypes(tpe)
+      .flatMap {
+        component =>
+          directBases(component) ++ component.typeArgs.flatMap(typeMemberComponentTypes).flatMap(directBases)
+      }
+      .filterNot {
+        case (t, parent) =>
+          parent == t
+      }
   }
 
   private[this] def makeLambdaOnlyBases(mainTpe: Type, allReferenceComponents: Iterator[Type]): List[(AbstractReference, AbstractReference)] = {

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/FullDbInspector.scala
@@ -1,6 +1,7 @@
 package izumi.reflect.dottyreflection
 
 import izumi.reflect.internal.fundamentals.collections.IzCollections.toRich
+import izumi.reflect.macrortti.LightTypeTagInheritance
 import izumi.reflect.macrortti.LightTypeTagRef
 import izumi.reflect.macrortti.LightTypeTagRef.*
 
@@ -174,16 +175,83 @@ abstract class FullDbInspector(protected val shift: Int) extends InspectorBase {
       val directBaseRefs = if (onlyIndirect) {
         Nil
       } else {
-        baseTypes.map {
+        baseTypes.flatMap {
           bt =>
             val parentRef = inspector.inspectTypeRepr(bt)
-            (selfRef, parentRef)
+            val (refinedParent, typeMemberBaseRefs) = typeMemberRefinementParentAndBases(tpe, bt, parentRef)
+            ((selfRef, parentRef) :: refinedParent.map(selfRef -> _).toList) ::: typeMemberBaseRefs
         }
       }
 
       val mainBasesRefs = recursiveParentRefs ::: directBaseRefs
 
       argBasesRefs ::: mainBasesRefs
+    }
+
+    private def typeMemberRefinementParentAndBases(
+      tpe: TypeRepr,
+      baseType: TypeRepr,
+      parentRef: AbstractReference
+    ): (Option[AbstractReference], List[(AbstractReference, AbstractReference)]) = {
+      val (typeMemberDecls, typeMemberBaseRefs) = baseType.typeSymbol.declaredTypes
+        .filter(member => !member.isTypeParam && !member.isClassDef && member.flags.is(Flags.Deferred))
+        .flatMap {
+          member =>
+            typeMemberRefinementDecl(tpe, member)
+        }.unzip
+
+      val decls: Set[RefinementDecl] = typeMemberDecls.toSet
+
+      parentRef match {
+        case parent: AppliedReference if decls.nonEmpty =>
+          (Some(LightTypeTagRef.Refinement(parent, decls)), typeMemberBaseRefs.flatten)
+        case _ =>
+          (None, typeMemberBaseRefs.flatten)
+      }
+    }
+
+    private def typeMemberRefinementDecl(tpe: TypeRepr, member: Symbol): Option[(RefinementDecl.TypeMember, List[(AbstractReference, AbstractReference)])] = {
+      resolveTypeMember(tpe, member.name).flatMap {
+        member =>
+          tpe.memberType(member) match {
+            case bounds: TypeBounds =>
+              val boundaries = inspectTypeBounds(bounds)
+              boundaries match {
+                case Boundaries.Defined(low, high) if low == high =>
+                  Some((RefinementDecl.TypeMember(member.name, high), processTypeBounds(bounds)))
+                case defined @ Boundaries.Defined(_, _) =>
+                  Some((RefinementDecl.TypeMember(member.name, NameReference(SymName.SymTypeName(member.name), defined, None)), processTypeBounds(bounds)))
+                case Boundaries.Empty =>
+                  None
+              }
+            case _ =>
+              None
+          }
+      }
+    }
+
+    private def resolveTypeMember(tpe: TypeRepr, name: String): Option[Symbol] = {
+      val candidates = (tpe.typeSymbol.declaredTypes ++ tpe.baseClasses.map(tpe.baseType).flatMap(_.typeSymbol.declaredTypes))
+        .filterNot(_.isTypeParam)
+        .filter(_.name == name)
+
+      candidates.find {
+        symbol =>
+          tpe.memberType(symbol) match {
+            case bounds: TypeBounds => inspectTypeBounds(bounds) != Boundaries.Empty
+            case _ => false
+          }
+      }
+    }
+
+    private def inspectTypeBounds(bounds: TypeBounds): Boundaries = {
+      val low = inspector.inspectTypeRepr(bounds.low)
+      val high = inspector.inspectTypeRepr(bounds.hi)
+      if (low == LightTypeTagInheritance.tpeNothing && high == LightTypeTagInheritance.tpeAny) {
+        Boundaries.Empty
+      } else {
+        Boundaries.Defined(low, high)
+      }
     }
 
     private def inspectTypeBoundsToFull(tpe: TypeRepr): List[(AbstractReference, AbstractReference)] = {

--- a/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala/izumi/reflect/macrortti/LightTypeTagInheritance.scala
@@ -217,14 +217,14 @@ final class LightTypeTagInheritance(self: LightTypeTag, other: LightTypeTag) {
   private def compareDecl(ctx: Ctx)(s: RefinementDecl, t: RefinementDecl): Boolean = (s, t) match {
     case (
           RefinementDecl.TypeMember(ln, lref),
-          RefinementDecl.TypeMember(rn, NameReference(SymName.SymTypeName(rn1), rBounds, None))
+          RefinementDecl.TypeMember(rn, NameReference(SymName.SymTypeName(rn1), rBounds, _))
         ) if rn == rn1 =>
       // we're comparing two abstract types type X = X|>:A<:B|
       // We know that the type is abstract if its name matches the type member's name
       ln == rn && compareBounds(ctx)(lref, rBounds)
     case (RefinementDecl.TypeMember(ln, lref), RefinementDecl.TypeMember(rn, rref)) =>
       // if the rhs type is not abstract (has form `type X = Int`), then lhs must be exactly equal to it, not <:
-      ln == rn && lref == rref
+      ln == rn && (lref == rref || (ctx.isChild(lref, rref) && ctx.isChild(rref, lref)))
     case (RefinementDecl.Signature(ln, lins, lout), RefinementDecl.Signature(rn, rins, rout)) =>
       (ln == rn
         && lins.iterator.zipAll(rins.iterator, null, null).forall {

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedLightTypeTagTest.scala
@@ -918,6 +918,17 @@ abstract class SharedLightTypeTagTest extends TagAssertions {
       assertNotChildStrict(LTT[{ def T: Int }], LTT[{ type T }])
     }
 
+    "support subtype checks against structural refinements of inherited type members" in {
+      assertChild(LTT[Issue481AInt], LTT[Issue481A { type T = Int }])
+      assertChild(LTT[Issue481AString], LTT[Issue481A { type T = String }])
+
+      assertNotChild(LTT[Issue481AInt], LTT[Issue481A { type T = String }])
+      assertNotChild(LTT[Issue481AString], LTT[Issue481A { type T = Int }])
+
+      assertChild(LTT[Issue481AInt], LTT[Issue481A { type T <: AnyVal }])
+      assertNotChild(LTT[Issue481AString], LTT[Issue481A { type T <: AnyVal }])
+    }
+
     "what about non-empty refinements with intersections" in {
       val ltt = LTT[Int with Object with Option[String] { def a: Boolean }]
       val debug = ltt.debug()

--- a/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
+++ b/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/TestModel.scala
@@ -108,6 +108,16 @@ object TestModel {
   type WithX = { type X }
   type FXS <: { type F[A] = A }
 
+  trait Issue481A {
+    type T
+  }
+  trait Issue481AInt extends Issue481A {
+    override type T = Int
+  }
+  trait Issue481AString extends Issue481A {
+    override type T = String
+  }
+
   trait H1
   trait H2 extends H1
   trait H3 extends H2


### PR DESCRIPTION
Fixes #481.

This updates full inheritance DB generation so concrete subclasses that resolve inherited abstract type members are also represented as children of the corresponding refined parent type.

For example:

- `Issue481AInt <: Issue481A { type T = Int }`
- `Issue481AString <: Issue481A { type T = String }`
- `Issue481AInt <: Issue481A { type T <: AnyVal }`
- `Issue481AString !<:< Issue481A { type T <: AnyVal }`

The implementation covers both Scala 2 and Scala 3 tag generation. It only synthesizes refined parent edges for abstract/deferred type members declared by base types, keeping the added inheritance DB entries scoped to the relevant case.

Tested:

- Scala 3: `izumi-reflectJVM / Test / testOnly izumi.reflect.test.LightTypeTagTest`
- Scala 2.13.14: `++2.13.14; izumi-reflectJVM / Test / testOnly izumi.reflect.test.LightTypeTagTest`
- Scala 2.12.20: `++2.12.20; izumi-reflectJVM / Test / testOnly izumi.reflect.test.LightTypeTagTest`
- Scala 2.11.12: `++2.11.12; izumi-reflectJVM / Test / testOnly izumi.reflect.test.LightTypeTagTest`

Also verified with `git diff --check`.
