### PR TITLE
Fix TagMacro on Scala 3.10+

### DIFF
--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -35,17 +35,17 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
     }
   }
 
-  private def createTag[A <: AnyKind](typeRepr0: TypeRepr): Expr[Tag[A]] = {
+  private def createTag[A <: AnyKind](typeRepr0: TypeRepr)(using Type[A]): Expr[Tag[A]] = {
     val typeRepr = typeRepr0._etaExpandTypeRef // convert HKT type refs to type lambdas manually as an optimization. This required an additional splice level before.
     val ltt = Inspect.inspectTypeRepr(typeRepr)
     val cls = closestClassOfTypeRepr(typeRepr)
     Apply(
       fun = TypeApply(
         fun = Select(qualifier = Ref.term(tagObjSymbol.termRef), symbol = tagObjApplyMethodSym),
-        args = List(Inferred(typeRepr))
+        args = List(TypeTree.of[A])
       ),
       args = List(cls.asTerm, ltt.asTerm)
-    ).asExpr.asInstanceOf[Expr[Tag[A]]]
+    ).asExprOf[Tag[A]]
   }
 
   private def summonCombinedTag[T <: AnyKind: Type](owners: Set[Symbol], typeReprDealiased: TypeRepr): Expr[Tag[T]] = {

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/TagMacro.scala
@@ -45,7 +45,7 @@ final class TagMacro(using override val qctx: Quotes) extends InspectorBase {
         args = List(TypeTree.of[A])
       ),
       args = List(cls.asTerm, ltt.asTerm)
-    ).asExprOf[Tag[A]]
+    ).asExpr.asInstanceOf[Expr[Tag[A]]]
   }
 
   private def summonCombinedTag[T <: AnyKind: Type](owners: Set[Symbol], typeReprDealiased: TypeRepr): Expr[Tag[T]] = {

--- a/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/ReflectionUtil.scala
+++ b/izumi-reflect/izumi-reflect/src/main/scala-3/izumi/reflect/dottyreflection/ReflectionUtil.scala
@@ -121,7 +121,10 @@ private[dottyreflection] trait ReflectionUtil { this: InspectorBase =>
 
   @nowarn("msg=anonymous class definition will be duplicated")
   inline private final def etaExpandImpl(tycon: TypeRepr, inline checkIfPartialApplication: List[TypeRepr] => Boolean): Option[TypeLambda] = {
-    val tparams0: List[TypeRepr] = tycon.typeSymbol.declaredTypes.collect { case s if s.isTypeParam => s._info }
+    val tyconSym = tycon.typeSymbol
+    val tparams0: List[TypeRepr] = tyconSym.declaredTypes.collect {
+      case s if s.isTypeParam && (s.owner == tyconSym) => s._info
+    }
     val tparams: List[TypeRepr] = if (checkIfPartialApplication(tparams0)) {
       tycon match {
         case typeParamRef: ParamRef =>
@@ -164,7 +167,7 @@ private[dottyreflection] trait ReflectionUtil { this: InspectorBase =>
         case _: LambdaType => true
         case tref: TypeRef =>
           val tsym = tref.typeSymbol
-          tsym.isType && tsym.declaredTypes.exists(_.isTypeParam)
+          tsym.isType && tsym.declaredTypes.exists(s => s.isTypeParam && (s.owner == tsym))
         case _ => false
       }
     }


### PR DESCRIPTION
Fixes issue spotted by Scala 3 Open Community Build - declaredTypes on type `O <: List[T]` leaks List’s `A`, so eta-expand invents a bogus `[0] =>> O[0]` resulting in. 

Under Scala 3.10 to be improved https://github.com/scala/scala3/pull/25756 however since it's a macro it's going to affect downstream users of izumi-reflect (3.3 LTS) on Scala 3.10 and onward 

Before this patch it resulted in  ([full build logs)](https://scala3.westeurope.cloudapp.azure.com/dashboard/projects/zio/izumi-reflect/builds/scheduled_3.10.0-RC1-bin-20260809-34f2030-NIGHTLY/logs)
```scala
[error] -- Error: /opencb/repo/zio/izumi-reflect/izumi-reflect/izumi-reflect/src/test/scala/izumi/reflect/test/SharedTagTest.scala:691:23
[error] 691 | assert(!Tag[ZY#O].hasPreciseClass)
[error] | ^
[error] |Macro expansion has type izumi.reflect.Tag[[0] =>> izumi.reflect.test.ZY#O[0]], which does not conform to the expected type izumi.reflect.Tag[izumi.reflect.test.ZY#O]
[error] |---------------------------------------------------------------------------
[error] |Inline stack trace
[error] |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error] |This location contains code that was inlined from Tags.scala:168
[error] 168 | inline implicit final def tagFromTagMacro[T <: AnyKind]: Tag[T] = ${ TagMacro.createTagExpr[T] }
[error] | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error] ---------------------------------------------------------------------------

```

Tested locally on `3.10.0-RC1-bin-20260813-afdb1e2-NIGHTLY`

With Scala 3.10.0 branch being cutoff next week, and since change in compiler is overall an imrovement it's likely going to stay 

If any other changes are required please feel free to take over this PR, as I might not be able to work on that .